### PR TITLE
Simplify DocMind bootstrap configuration

### DIFF
--- a/samples/S13.DocMind/Program.cs
+++ b/samples/S13.DocMind/Program.cs
@@ -1,16 +1,10 @@
 using Koan.Core;
-using Koan.Core.Modules;
-using Koan.Core.Observability;
-using Koan.Data.Core;
 using Koan.Web.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Koan Framework initialization
 builder.Services.AddKoan();
-
-// Add Koan observability for proper startup sequence logging
-builder.Services.AddKoanObservability();
 
 // Note: Service implementations are handled by Koan auto-registration
 


### PR DESCRIPTION
## Summary
- streamline the DocMind sample startup to rely on Koan's automatic web pipeline wiring
- remove explicit observability registration now handled by the framework defaults

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68d6f4135e3483288238ca04d33f7a70