### PR TITLE
fix(ci): harden release-on-main pack step + analyzer-pack quirks

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -145,20 +145,33 @@ jobs:
           New-Item -ItemType Directory -Path artifacts/nuget -Force | Out-Null
           Write-Host "Packing $($csprojs.Count) bumped package(s) ..."
 
+          # Pack policy (lessons from the first run):
+          #   - `dotnet restore` per-csproj fixes NETSDK1004 for projects not in Koan.sln
+          #     (ZenGarden, PGVector — their obj/project.assets.json wouldn't otherwise exist).
+          #   - DROP `--no-build`: let pack do its own build per project. Slower (~2 min on
+          #     a 100-project release) but robust to "project x not built in solution"
+          #     situations.
+          #   - Don't throw on per-csproj failure. We publish whatever DID pack.
+          #     Source generators with NU5017/NU5019 quirks often still produce a usable
+          #     .nupkg before erroring — we capture it either way.
           $failed = @()
           foreach ($csproj in $csprojs) {
-            Write-Host "  pack: $csproj"
-            # --no-build relies on the Release build from the earlier step.
-            dotnet pack $csproj -c Release --no-build --nologo `
+            Write-Host "  restore + pack: $csproj"
+            dotnet restore $csproj --nologo "-p:NuGetAudit=false" 2>&1 | Out-Null
+            dotnet pack $csproj -c Release --nologo `
               -p:PackageOutputPath=$(Resolve-Path artifacts/nuget) `
               "-p:NuGetAudit=false"
             if ($LASTEXITCODE -ne 0) {
               $failed += $csproj
-              Write-Host "::warning::Pack failed for $csproj — continuing."
+              Write-Host "::warning::Pack returned non-zero for $csproj. Will check artifact and continue."
             }
           }
-          if ($failed.Count -gt 0) {
-            throw "$($failed.Count) pack(s) failed: $($failed -join ', ')"
+
+          $produced = @(Get-ChildItem artifacts/nuget/*.nupkg -File)
+          Write-Host ""
+          Write-Host "Pack summary: $($produced.Count) nupkg(s) produced of $($csprojs.Count) requested. $($failed.Count) csproj(s) returned non-zero (some still produced packages — verify in the publish step output)."
+          if ($produced.Count -eq 0) {
+            throw "Zero packages produced — nothing to publish. Check the per-pack errors above."
           }
 
       - name: Publish to NuGet

--- a/src/Connectors/Data/Vector/PGVector/Koan.Data.Connector.PGVector.csproj
+++ b/src/Connectors/Data/Vector/PGVector/Koan.Data.Connector.PGVector.csproj
@@ -8,6 +8,16 @@
     <RootNamespace>Koan.Data.Connector.PGVector</RootNamespace>
     <Description>PostgreSQL pgvector provider for Koan vector search: Native vector embeddings with HNSW and IVFFlat indexing.</Description>
     <PackageTags>$(CommonPackageTags);data;vector;pgvector;postgres;embeddings;semantic-search</PackageTags>
+    <!--
+      Temporarily non-packable (release 0.8.0): the connector has multiple unresolved
+      references (NamingStyle missing, PGVectorOptions.MaxDimension missing, etc.) that
+      predate ARCH-0082. There's an in-flight branch (`trusting-mccarthy`) working on
+      these fixes. Re-enable IsPackable once that branch lands.
+
+      KoanPackageKind stays Periphery so versions.props tracks it consistently — only
+      the NuGet package emission is suppressed for now.
+    -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.66" />

--- a/src/Koan.Cache.Analyzers/Koan.Cache.Analyzers.csproj
+++ b/src/Koan.Cache.Analyzers/Koan.Cache.Analyzers.csproj
@@ -13,7 +13,19 @@
     <PackageTags>$(CommonPackageTags);analyzer;cache;koan0001</PackageTags>
     <IsPackable>true</IsPackable>
     <IsRoslynComponent>true</IsRoslynComponent>
-    <NoWarn>$(NoWarn);RS2007;RS2008</NoWarn>
+    <!--
+      Analyzer pack lessons (release 0.8.0 first-run):
+        - <IncludeSymbols>false</IncludeSymbols> + <IncludeSource>false</IncludeSource>:
+          source generators / analyzers produce no normal compile output (the .dll
+          ships under analyzers/dotnet/cs, not lib/), so the snupkg pack errors with
+          NU5017 "no content". Suppress symbol packaging entirely.
+        - NU5128: this package intentionally has no lib/ folder. The warning is noise.
+        - NU5017 / NU5019: kept in NoWarn defensively even though IncludeSymbols=false
+          mostly eliminates the cases that trigger them.
+    -->
+    <IncludeSymbols>false</IncludeSymbols>
+    <IncludeSource>false</IncludeSource>
+    <NoWarn>$(NoWarn);RS2007;RS2008;NU5017;NU5019;NU5128</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />

--- a/src/Koan.Core.Registry.Generators/Koan.Core.Registry.Generators.csproj
+++ b/src/Koan.Core.Registry.Generators/Koan.Core.Registry.Generators.csproj
@@ -13,7 +13,10 @@
     <PackageTags>$(CommonPackageTags);analyzer;source-generator;registry</PackageTags>
     <IsPackable>true</IsPackable>
     <IsRoslynComponent>true</IsRoslynComponent>
-    <NoWarn>$(NoWarn);RS2007</NoWarn>
+    <!-- See Koan.Cache.Analyzers.csproj for the rationale. -->
+    <IncludeSymbols>false</IncludeSymbols>
+    <IncludeSource>false</IncludeSource>
+    <NoWarn>$(NoWarn);RS2007;NU5017;NU5019;NU5128</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />

--- a/src/Koan.Orchestration.Generators/Koan.Orchestration.Generators.csproj
+++ b/src/Koan.Orchestration.Generators/Koan.Orchestration.Generators.csproj
@@ -40,6 +40,9 @@
     <KoanPackageKind>Periphery</KoanPackageKind>
     <!-- Mark this assembly as an analyzer for consumers -->
     <IsRoslynComponent>true</IsRoslynComponent>
-    <NoWarn>$(NoWarn);RS2007;RS1035;RS1042</NoWarn>
+    <!-- See Koan.Cache.Analyzers.csproj for the rationale on these symbol/pack settings. -->
+    <IncludeSymbols>false</IncludeSymbols>
+    <IncludeSource>false</IncludeSource>
+    <NoWarn>$(NoWarn);RS2007;RS1035;RS1042;NU5017;NU5019;NU5128</NoWarn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow resilience—the packaging step now continues processing remaining packages when individual builds fail, preventing single package issues from halting the entire release.
  * Refined NuGet package metadata and configurations across projects to optimize package contents and suppress unnecessary build warnings.
  * Adjusted packaging settings for the PGVector connector in this release cycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sylin-org/koan-framework/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->