### PR TITLE
Publish only the guaranteed 0.20 package closure

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           global-json-file: global.json
 
-      - name: Require project-local versions
-        run: dotnet run --project tools/Koan.Packaging -- inventory --output artifacts/package-inventory.json
+      - name: Resolve guaranteed package scope
+        run: dotnet run --project tools/Koan.Packaging -- product-surface --output artifacts/product-surface.json
 
       - name: Pack
         shell: pwsh
@@ -45,10 +45,28 @@ jobs:
             throw 'Repository secret NUGET_API_KEY is required.'
           }
 
-          $packages = @(Get-ChildItem artifacts/packages -Recurse -Filter *.nupkg -File)
-          if ($packages.Count -eq 0) {
-            throw 'Pack produced no NuGet packages.'
+          $surface = Get-Content artifacts/product-surface.json -Raw | ConvertFrom-Json
+          $releaseIds = @($surface.packages |
+            Where-Object { $_.versionIntent -eq '0.20' } |
+            ForEach-Object { $_.packageId } |
+            Sort-Object)
+          if ($releaseIds.Count -eq 0) {
+            throw 'Product surface selected no guaranteed 0.20 packages.'
           }
+
+          $artifacts = @(Get-ChildItem artifacts/packages -Recurse -Filter *.nupkg -File)
+          $packages = @(
+            foreach ($packageId in $releaseIds) {
+              $prefix = "$packageId.0.20."
+              $matches = @($artifacts | Where-Object {
+                $_.Name.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)
+              })
+              if ($matches.Count -ne 1) {
+                throw "Guaranteed package '$packageId' matched $($matches.Count) packed 0.20 artifacts; expected exactly one."
+              }
+              $matches[0]
+            }
+          )
 
           foreach ($package in $packages) {
             dotnet nuget push $package.FullName `

--- a/docs/decisions/ARCH-0110-main-release-boundary.md
+++ b/docs/decisions/ARCH-0110-main-release-boundary.md
@@ -28,8 +28,10 @@ single package release job on `push` to `main`. Commits and pull requests target
 neither path.
 
 **Guarantee/correction:** Only source present on `main` can receive the NuGet credential and reach
-publication. A rejected credential, invalid version owner, pack error, or registry failure stops the
-job; after correcting the cause, rerun the same `main` workflow run.
+publication. Product-surface compilation selects exactly the supported 0.20 package closure; lower
+maturity packages cannot be pushed by the job. A rejected credential, invalid version owner,
+release-scope/artifact mismatch, pack error, or registry failure stops the job; after correcting the
+cause, rerun the same `main` workflow run.
 
 **Complete intent surface:** Open and merge a pull request to `main`, or deliberately commit to
 `main`. No manual release dispatch, branch selector, release branch, tag, GitHub Release, package
@@ -61,10 +63,11 @@ repository job and uses only the established `NUGET_API_KEY` for nuget.org publi
 The job:
 
 1. checks out full Git history;
-2. verifies evaluated packable projects have local version owners;
+2. compiles the evaluated product surface, proving that supported claims and 0.20 version owners are
+   the same package set;
 3. runs standard `dotnet pack` with `PublicRelease=true` for the solution and the one packable
    template project intentionally outside it; and
-4. runs standard `dotnet nuget push --skip-duplicate` for the resulting packages.
+4. runs standard `dotnet nuget push --skip-duplicate` only for that guaranteed 0.20 set.
 
 The release job does not run the repository test ratchet, create Git commits or branches, create tags
 or GitHub Releases, stage escrow, or maintain recovery state. Validation belongs to the existing PR
@@ -81,6 +84,8 @@ stops the job and is corrected at its ordinary owner before rerunning.
 - A `dev` commit causes no validation or publication workflow activity.
 - A pull request targeting `main` validates but cannot publish.
 - The resulting `main` commit automatically invokes the one publication job.
+- Packing may produce lower-maturity artifacts for build completeness, but publication selects only
+  the product-surface package IDs validated at 0.20.
 - Version ownership remains local, explicit, and independently inspectable.
 - Multi-package publication is not atomic; short-lived partial availability is accepted for the
   pre-release rather than simulated through a Koan-owned transaction system.

--- a/docs/engineering/nuget-publishing.md
+++ b/docs/engineering/nuget-publishing.md
@@ -28,13 +28,15 @@ state store is required.
 The one job:
 
 1. checks out full Git history from `main` so NBGV can calculate package versions;
-2. evaluates package inventory and requires a local `version.json` for every packable project;
+2. compiles the product surface, requiring local `version.json` ownership and exact agreement between
+   supported claims and the 0.20 package closure;
 3. packs the solution and the packable template project with `PublicRelease=true`; and
-4. pushes every resulting nupkg with `--skip-duplicate`.
+4. pushes only the selected 0.20 nupkgs with `--skip-duplicate`.
 
 NuGet package identities are immutable. Rerunning the failed workflow run skips identities already
 present and attempts the remaining packages. A missing key, invalid version owner, pack failure, or
-push failure stops the job.
+push failure stops the job. A selected package with zero or multiple matching artifacts also stops
+before that identity is pushed.
 
 ## Version changes
 

--- a/docs/engineering/packaging.md
+++ b/docs/engineering/packaging.md
@@ -42,8 +42,10 @@ These commands inspect product/package shape. They do not stage or publish anyth
 
 Merge the intended source into `main`. The resulting `main` commit runs **Release packages**, which
 packs the solution and the packable template project with `PublicRelease=true`, then pushes the
-produced nupkgs using the repository's `NUGET_API_KEY`. Existing immutable identities are skipped;
-any other failure stops the job. Development commits and open pull requests cannot publish.
+guaranteed product-surface packages whose validated version intent is `0.20`, using the repository's
+`NUGET_API_KEY`. Lower-maturity package artifacts are not published. Existing immutable identities
+are skipped; any other failure stops the job. Development commits and open pull requests cannot
+publish.
 
 Do not maintain package checklists, hand-authored manifests, release branches, escrow formats, or
 recovery ledgers. NuGet owns immutable publication; Git and each local `version.json` own identity.

--- a/docs/initiatives/koan-v1/NOW.md
+++ b/docs/initiatives/koan-v1/NOW.md
@@ -24,8 +24,9 @@ is recorded in [R12-06](work-items/r12/R12-06-publish-and-observe-first-wave.md)
 - pull requests targeting `main` run the existing validation gate but cannot publish;
 - the resulting `main` commit automatically runs one package publication job;
 - each packable project keeps its local NBGV `version.json`;
-- the workflow evaluates inventory, runs `dotnet pack` with `PublicRelease=true`, and runs
-  `dotnet nuget push --skip-duplicate` using the established `NUGET_API_KEY`;
+- the workflow compiles the product surface, runs `dotnet pack` with `PublicRelease=true`, and runs
+  `dotnet nuget push --skip-duplicate` only for the 38 guaranteed package owners validated at 0.20,
+  using the established `NUGET_API_KEY`;
 - no lineage branch, synthetic commits, manifests, escrow, tags, GitHub Releases, recovery ledger,
   duplicated proof lanes, or full test ratchet participates in publication.
 
@@ -47,8 +48,13 @@ Focused implementation evidence:
 
 ## Remote/public state
 
-- No 0.20 package was published by the abandoned release compiler or the three failed/cancelled
-  bare-bones attempts. The cancelled credential retry skipped its publication step.
+- `Sylin.Koan 0.20.4` was accepted by nuget.org from main-boundary run `29790423844`; registry indexing
+  may lag acceptance. The run then exposed and stopped on an invalid attempt to publish
+  non-guaranteed `Sylin.Koan.AI 0.18.10`. Release selection is now restricted to the guaranteed 0.20
+  closure.
+- NuGet ownership remains split across `sylin.org` and the historical `sylin-labs` owner. Eighteen
+  guaranteed existing IDs require ownership transfer or an old-owner credential; new IDs require
+  create-package permission. This is the current external prerequisite.
 - No `automation/package-lineage-dev` branch, `release/dev/*` tag, release-wave escrow, or GitHub
   Release was created.
 - There is no manual dispatch path. Do not update `main` during local correction because a `main`

--- a/docs/initiatives/koan-v1/work-items/r12/R12-06-publish-and-observe-first-wave.md
+++ b/docs/initiatives/koan-v1/work-items/r12/R12-06-publish-and-observe-first-wave.md
@@ -27,10 +27,11 @@ Nerdbank.GitVersioning computes its public package version; the established `NUG
 only credential.
 
 **Guarantee/correction:** Only source present on `main` can receive the NuGet credential. The workflow
-evaluates the repository's packable projects, packs each with `PublicRelease=true`, and pushes the
-resulting packages to nuget.org. A missing API key, invalid or missing version owner, restore/pack
-failure, or NuGet push failure stops the single job. Existing immutable package identities are
-skipped by NuGet; rerun the failed `main` workflow after correcting the owner.
+evaluates the repository's product surface, packs with `PublicRelease=true`, and pushes only the
+guaranteed packages whose validated version intent is `0.20`. A missing API key, invalid or missing
+version owner, release-scope/artifact mismatch, restore/pack failure, or NuGet push failure stops the
+single job. Existing immutable package identities are skipped by NuGet; rerun the failed `main`
+workflow after correcting the owner.
 
 **Complete intent surface:** Change a package's major/minor in its own `version.json` only when its
 compatibility tier changes; open and merge a pull request to `main` (or deliberately commit directly
@@ -108,7 +109,8 @@ system inside Koan.
 
 1. Publish only on push to `main`; validate pull requests to `main`; trigger nothing from `dev`.
 2. Pack every evaluated packable project with its NBGV public version.
-3. Push the resulting nupkgs with the established API key and duplicate-safe NuGet semantics.
+3. Push only the product-surface packages whose supported promise and `0.20` version intent agree,
+   using the established API key and duplicate-safe NuGet semantics.
 4. Remove the unused lineage, escrow, coordinator, recovery, and clean-room release implementation.
 5. Realign current engineering guidance and mark the former compiler decision superseded.
 6. Build only `Koan.Packaging` and perform a static workflow check. Do not run the release ratchet.
@@ -116,7 +118,8 @@ system inside Koan.
 ## Acceptance
 
 1. Release is one `main`-push workflow, one job, and one API key; `dev` activity does nothing.
-2. Every packable project is discovered through evaluated MSBuild state and owns `version.json`.
+2. Every packable project is discovered through evaluated MSBuild state and owns `version.json`;
+   product-surface compilation selects exactly the guaranteed 0.20 closure for publication.
 3. NBGV remains the sole package/assembly version source and `PublicRelease=true` removes local
    build suffixes.
 4. The workflow restores, packs, and pushes; it does not test the repository, create Git history,
@@ -134,7 +137,47 @@ system inside Koan.
 - The packaging test project compiles after removal of the release-specific source set; tests were
   deliberately not executed.
 - Three manual-from-`dev` attempts failed before publication and one credential retry was cancelled
-  during packing; no attempt published a package. The manual path is now removed.
+  during packing. The first main-boundary run published `Sylin.Koan 0.20.4`, then exposed the blind
+  release-set bug by attempting non-guaranteed `Sylin.Koan.AI 0.18.10`; NuGet rejected that second
+  package. The manual path is removed and release selection is corrected below.
+
+## Guaranteed release-scope correction — 2026-07-20
+
+**Task:** Publish exactly the guaranteed 0.20 package closure rather than every package artifact.
+
+**Application intent:** A `main` commit publishes the packages Koan promises at 0.20—nothing merely
+present, demonstrated, experimental, specified, or unassessed.
+
+**Public expression:** Run the existing `Koan.Packaging product-surface` compiler, select its packages
+whose validated `versionIntent` is `0.20`, and push only the corresponding nupkgs with standard NuGet
+commands.
+
+**Guarantee/correction:** `ProductSurfaceCompiler` already enforces both directions: every package
+owned by a supported claim declares `0.20`, and every `0.20` package belongs to a supported claim.
+Publication rejects a selected ID unless packing produced exactly one matching 0.20 artifact.
+
+**Complete intent surface:** Maintain `product/claims.json` and project-local `version.json` files;
+merge to `main`; inspect the one workflow result. No hand-authored release list, second manifest, new
+command, or package-specific operator choice is added.
+
+**Public concepts:** Product claims own support, NBGV `version.json` owns compatibility intent, and
+NuGet owns immutable identities. No release-specific Koan concept is exposed.
+
+**Coalescence:** Keep product-surface compilation as the one support-selection owner, consume its
+ordinary JSON in the existing workflow, and delete blind “push every nupkg” behavior. A release
+manifest or package-selection command would duplicate the product surface; version-only selection is
+safe because the compiler already proves exact equivalence between supported ownership and 0.20.
+
+**Ergonomics:** The maintainer action remains merge-to-`main`. The job derives the release set, logs
+each selected identity, and fails with the exact missing/ambiguous artifact rather than publishing a
+lower-maturity package.
+
+**Observed external ownership:** The guaranteed closure contains 38 IDs. At observation time, 18
+existing packages were owned by `sylin-labs`, 17 IDs did not yet exist, two existing packages were
+owned by `sylin.org`, and one package page did not return a stable owner result. The current key
+successfully created `Sylin.Koan 0.20.4` but cannot update the old-owner packages. Repository selection
+is corrected independently; ownership transfer or an appropriately authorized credential remains a
+NuGet account prerequisite, not release code.
 
 ## Standard template-pack checkpoint — 2026-07-20
 


### PR DESCRIPTION
## What changed

- derive the release set from the existing product-surface compiler
- publish only package IDs whose supported promise and `versionIntent=0.20` agree
- fail if a guaranteed ID does not map to exactly one packed 0.20 artifact
- record the first main-boundary publication and the external NuGet ownership split

## Root cause

The simplified workflow packed and pushed all 93 package projects. The first main run accepted `Sylin.Koan 0.20.4`, then incorrectly attempted non-guaranteed `Sylin.Koan.AI 0.18.10` and failed.

## Impact

The next release can attempt only the 38 guaranteed packages. Lower-maturity artifacts remain buildable but cannot be published by this job.

## Checks

- product-surface compilation: 29 claims / 93 packages
- guaranteed selection: 38 selected, lower-maturity AI excluded
- workflow YAML parse: passed
- `git diff --check`: passed
- dev push produced zero Actions runs

## External prerequisite before merge

NuGet ownership is split: 18 guaranteed existing IDs are still owned by `sylin-labs`, while the active credential published under `sylin.org`. Transfer those IDs or provide an authorized old-owner publication path before merging this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Releases now publish only validated `0.20` product packages, preventing unintended or lower-maturity packages from being pushed.
  - Package selection is deterministic, with releases stopping when expected packages are missing or ambiguous.
  - Existing package identities continue to be skipped safely during reruns.

- **Documentation**
  - Updated release, packaging, and project guidance to reflect the constrained publication process and its validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->