### PR TITLE
Fix the public-feed template journey

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,33 +6,13 @@ code states business intent while the framework owns composition, backend negoti
 and explanation.
 
 > **Status:** Koan 0.20 is the preview line. Its supported foundation and extensions are explicit;
-> other available packages remain verified, demonstrated, experimental, specified, or unassessed. Public-feed
-> publication follows the final package-only proof. Until then, run the checkout directly and use the
-> [generated product surface](docs/reference/product-surface.md) as the maturity authority.
+> other available packages remain verified, demonstrated, experimental, specified, or unassessed. The supported
+> 0.20 package set is live on NuGet; use the [generated product surface](docs/reference/product-surface.md) as the
+> maturity authority.
 
 ## Reach a meaningful result
 
-Today, run the executable first-use contract from source:
-
-```powershell
-git clone https://github.com/sylin-org/koan-framework
-cd koan-framework
-dotnet run --project samples/FirstUse
-```
-
-In another shell, create a business request and inspect what composed it:
-
-```powershell
-Invoke-RestMethod -Method Post -Uri http://localhost:5000/api/approvals `
-  -ContentType application/json -Body '{"subject":"Approve supplier invoice"}'
-Invoke-RestMethod http://localhost:5000/api/approvals
-Invoke-RestMethod http://localhost:5000/.well-known/Koan/facts
-```
-
-Use the URL printed by the application if it differs. The complete walkthrough is in
-[`samples/FirstUse`](samples/FirstUse/README.md).
-
-After the first 0.20 wave is visible on NuGet, the canonical entry becomes the ordinary template path:
+Install the template from NuGet and create a persisted web API:
 
 ```powershell
 dotnet new install Sylin.Koan.Templates
@@ -41,8 +21,18 @@ cd TodoApi
 dotnet run
 ```
 
-That template creates a `Todo` application and exposes `/api/todos`; its complete result is in
-[the template guide](templates/README.md). Candidate package evidence is not public-feed availability.
+In another shell, create and read a Todo and inspect what composed it:
+
+```powershell
+Invoke-RestMethod -Method Post -Uri http://localhost:5000/api/todos `
+  -ContentType application/json -Body '{"title":"buy milk"}'
+Invoke-RestMethod http://localhost:5000/api/todos
+Invoke-RestMethod http://localhost:5000/.well-known/Koan/facts
+```
+
+Use the URL printed by the application if it differs. The complete result is in
+[the template guide](templates/README.md); repository contributors can inspect the richer executable contract in
+[`samples/FirstUse`](samples/FirstUse/README.md).
 
 ## The application grammar
 

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -4,12 +4,12 @@ domain: core
 title: "Getting started with Koan"
 audience: [developers, architects, ai-agents]
 status: current
-last_updated: 2026-07-19
+last_updated: 2026-07-21
 framework_version: v0.20.0
 validation:
-  date_last_tested: 2026-07-19
+  date_last_tested: 2026-07-21
   status: passed
-  scope: source-built 0.20 Entity-first grammar and graduated capability examples
+  scope: public package-first 0.20 Entity grammar and graduated capability examples
 ---
 
 # Getting started with Koan
@@ -18,9 +18,8 @@ Koan's golden path is V0 to V1 in meaningful small steps. Each new line should e
 decision or a deliberate capability; framework and adapter mechanics stay behind stable semantic
 chokepoints.
 
-> **0.20 preview:** run `dotnet run --project samples/FirstUse` from the source checkout today. After the first
-> public wave is visible on NuGet, `dotnet new install Sylin.Koan.Templates` becomes the canonical entry. The exact
-> candidate has local package evidence, but local evidence is not public availability.
+> **0.20 preview:** `dotnet new install Sylin.Koan.Templates` is the canonical public entry. The live package path
+> has been observed through generation, clean restore/build, SQLite persistence, HTTP create/read, and runtime facts.
 
 ## Step 1 — make one Entity useful
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -4,42 +4,17 @@ domain: core
 title: "Koan quickstart"
 audience: [developers, ai-agents]
 status: current
-last_updated: 2026-07-19
+last_updated: 2026-07-21
 framework_version: v0.20.0
 validation:
-  date_last_tested: 2026-07-19
+  date_last_tested: 2026-07-21
   status: passed
-  scope: 0.20 package-first contract plus source-built FirstUse fallback
+  scope: public 0.20 template install, clean restore/build, SQLite-backed REST create/read, and runtime facts
 ---
 
 # Koan quickstart
 
-Public-feed publication is still pending, so run the source-built FirstUse contract today:
-
-```powershell
-git clone https://github.com/sylin-org/koan-framework
-cd koan-framework
-dotnet run --project samples/FirstUse
-```
-
-In another shell:
-
-```powershell
-Invoke-RestMethod -Method Post -Uri http://localhost:5000/api/approvals `
-  -ContentType application/json -Body '{"subject":"Approve supplier invoice"}'
-Invoke-RestMethod http://localhost:5000/api/approvals
-$filter = [uri]::EscapeDataString('{"subject":"Approve supplier invoice"}')
-Invoke-RestMethod "http://localhost:5000/api/approvals?filter=$filter"
-Invoke-RestMethod http://localhost:5000/.well-known/Koan/facts
-```
-
-The URL printed by ASP.NET Core is authoritative if it differs. The POST persists an approval; the
-two reads prove ordinary and filtered Entity access; the facts response explains the modules and
-SQLite election that produced the result.
-
-## Package-first entry after publication
-
-After the first 0.20 wave is visible on NuGet, use the canonical template path:
+Install the public template and create the application:
 
 ```powershell
 dotnet new install Sylin.Koan.Templates
@@ -48,13 +23,22 @@ cd TodoApi
 dotnet run
 ```
 
-That generated application uses `Todo` and `/api/todos`. The [template guide](../../templates/README.md)
-contains its exact result. Until publication, these commands describe the proved candidate rather than an
-installable public package.
+In another shell:
+
+```powershell
+Invoke-RestMethod -Method Post -Uri http://localhost:5000/api/todos `
+  -ContentType application/json -Body '{"title":"buy milk"}'
+Invoke-RestMethod http://localhost:5000/api/todos
+Invoke-RestMethod http://localhost:5000/.well-known/Koan/facts
+```
+
+The URL printed by ASP.NET Core is authoritative if it differs. The POST persists a Todo; the read proves
+ordinary Entity access; the facts response explains the modules and SQLite election that produced the result.
+The [template guide](../../templates/README.md) contains the exact generated shape.
 
 ## Read the whole application
 
-Read [`samples/FirstUse`](../../samples/FirstUse/README.md) in this order:
+Repository contributors can read [`samples/FirstUse`](../../samples/FirstUse/README.md) in this order:
 
 1. `Domain/Approval.cs` — business state and access policy.
 2. `Web/ApprovalsController.cs` — the governed HTTP surface.
@@ -79,8 +63,8 @@ FirstUse is exercised through its real host. Focused evidence covers REST, SQLit
 filtered query, readiness, composition facts, MCP discovery, access policy, dry-run, and an agent
 write observed through REST. Its checked-in `koan.lock.json` records referenced composition.
 
-The release tooling also rebuilds the templates and this application from the exact locally staged package closure.
-That proves the candidate path; only public-feed observation will make the install command externally available.
+The public-feed journey has been observed independently: template installation, generation, clean restore/build,
+SQLite-backed REST create/read, and runtime facts all pass without repository package sources.
 
 ## Continue
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,12 +4,12 @@ domain: framework
 title: "Koan documentation"
 audience: [developers, architects, ai-agents]
 status: current
-last_updated: 2026-07-17
+last_updated: 2026-07-21
 framework_version: v0.20.0
 validation:
-  date_last_tested: 2026-07-17
-  status: in-progress
-  scope: public documentation front door and executable FirstUse path
+  date_last_tested: 2026-07-21
+  status: passed
+  scope: public template install, generation, clean restore/build, SQLite Entity result, and runtime facts
 ---
 
 # Koan documentation
@@ -20,27 +20,7 @@ lifecycle, and explanation.
 
 ## Start with a result
 
-While public-feed publication is pending, start with the executable source contract:
-
-```powershell
-git clone https://github.com/sylin-org/koan-framework
-cd koan-framework
-dotnet run --project samples/FirstUse
-```
-
-Then create and inspect one approval:
-
-```powershell
-Invoke-RestMethod -Method Post -Uri http://localhost:5000/api/approvals `
-  -ContentType application/json -Body '{"subject":"Approve supplier invoice"}'
-Invoke-RestMethod http://localhost:5000/api/approvals
-Invoke-RestMethod http://localhost:5000/.well-known/Koan/facts
-```
-
-Use the URL printed by the application if it differs. The [quickstart](getting-started/quickstart.md)
-explains the result; [FirstUse](../samples/FirstUse/README.md) is the executable contract.
-
-After the first 0.20 wave is visible on NuGet, the canonical entry becomes:
+Install the public template and create a persisted web API:
 
 ```powershell
 dotnet new install Sylin.Koan.Templates
@@ -49,8 +29,17 @@ cd TodoApi
 dotnet run
 ```
 
-The template's business result uses `Todo` and `/api/todos`; local candidate proof does not imply public
-package availability.
+Then create and inspect one Todo:
+
+```powershell
+Invoke-RestMethod -Method Post -Uri http://localhost:5000/api/todos `
+  -ContentType application/json -Body '{"title":"buy milk"}'
+Invoke-RestMethod http://localhost:5000/api/todos
+Invoke-RestMethod http://localhost:5000/.well-known/Koan/facts
+```
+
+Use the URL printed by the application if it differs. The [quickstart](getting-started/quickstart.md)
+explains the result; [FirstUse](../samples/FirstUse/README.md) is the richer repository-owned executable contract.
 
 ## Read business, not plumbing
 

--- a/docs/initiatives/koan-v1/NOW.md
+++ b/docs/initiatives/koan-v1/NOW.md
@@ -2,7 +2,7 @@
 type: HANDOFF
 domain: koan-v1
 status: active
-last_updated: 2026-07-20
+last_updated: 2026-07-21
 framework_version: v0.20.0
 ---
 
@@ -13,7 +13,7 @@ framework_version: v0.20.0
 Finish the road to the 0.20 pre-release with product work and a coherent public narrative. Release
 automation is infrastructure, not a product capability, and must remain proportionate.
 
-## Active slice: R12-06 bare-bones publication
+## Active slice: R12-06 published; public-feed observation next
 
 The maintainer rejected the automatic release compiler after multiple long validation cycles exposed
 failures in release orchestration rather than framework behavior. The later manual-from-`dev`
@@ -48,17 +48,17 @@ Focused implementation evidence:
 
 ## Remote/public state
 
-- `Sylin.Koan 0.20.4` was accepted by nuget.org from main-boundary run `29790423844`; registry indexing
-  may lag acceptance. The run then exposed and stopped on an invalid attempt to publish
-  non-guaranteed `Sylin.Koan.AI 0.18.10`. Release selection is now restricted to the guaranteed 0.20
-  closure.
-- NuGet ownership remains split across `sylin.org` and the historical `sylin-labs` owner. Eighteen
-  guaranteed existing IDs require ownership transfer or an old-owner credential; new IDs require
-  create-package permission. This is the current external prerequisite.
+- PR `#93` merged to `main` as `ad9d739199da809fa44efc9a4ce3db8059348b42`. Main-boundary run
+  `29792486934` succeeded: product-surface selection resolved the exact 38-package guaranteed 0.20
+  closure, packing completed, and NuGet accepted the publication set.
+- The historical `sylin-labs` NuGet organization is retired. Ownership of all 166 indexed historical
+  Sora and Koan package IDs was preserved under `sylin.org`; the authenticated account reports one
+  organization, `sylin.org`, with 240 packages. No packages were deleted or unlisted. Public owner
+  search is eventually consistent and may temporarily report stale `sylin-labs` results.
 - No `automation/package-lineage-dev` branch, `release/dev/*` tag, release-wave escrow, or GitHub
   Release was created.
-- There is no manual dispatch path. Do not update `main` during local correction because a `main`
-  commit is now the publication event.
+- There is no manual dispatch path. Any future `main` commit is a publication event; work on `dev`
+  triggers nothing.
 
 ## Validation posture
 
@@ -71,17 +71,17 @@ Focused implementation evidence:
 
 ## Next actions
 
-1. Commit the corrected main-boundary workflow and documentation to `dev`; this triggers nothing.
-2. Open a pull request targeting `main`; the PR gate validates but does not publish.
-3. Merge only when publication is intended; observe ordinary pack/push results from that `main`
-   commit, correct only a concrete failing owner, and rerun the same workflow run if necessary.
-4. Resume product and public-documentation work. Do not expand release infrastructure.
+1. Perform one focused public-feed consumer observation against the live 0.20 packages: restore the
+   documented first-use path from NuGet and record only concrete failures.
+2. Reconcile R12-05's pre-publication language with the completed minimal release; do not revive the
+   removed release compiler or full certification bureaucracy.
+3. Resume product and coherent public-documentation work. Do not expand release infrastructure.
 
 ## Repository boundaries
 
 - Preserve unrelated worktree changes and untracked `tmp/`; never stage `tmp/`.
 - Do not inspect private dogfood applications.
-- Do not update `main`, publish from a workstation, tag, release, or mutate remote configuration while
-  correcting the workflow on `dev`.
+- Do not publish from a workstation, tag, create a GitHub Release, or mutate unrelated remote
+  configuration.
 - Full release certification belongs to an explicitly requested milestone, not normal development or
   a release plumbing correction.

--- a/docs/initiatives/koan-v1/NOW.md
+++ b/docs/initiatives/koan-v1/NOW.md
@@ -13,7 +13,7 @@ framework_version: v0.20.0
 Finish the road to the 0.20 pre-release with product work and a coherent public narrative. Release
 automation is infrastructure, not a product capability, and must remain proportionate.
 
-## Active slice: R12-06 published; public-feed observation next
+## Active slice: public-feed first use observed; clean-template correction ready
 
 The maintainer rejected the automatic release compiler after multiple long validation cycles exposed
 failures in release orchestration rather than framework behavior. The later manual-from-`dev`
@@ -45,6 +45,15 @@ Focused implementation evidence:
   legacy release state;
 - `Sylin.Koan.Templates` is the one packable project outside `Koan.sln` and has one explicit standard
   pack command in the same job.
+- Public `Sylin.Koan.Templates 0.20.5` installs and generates successfully. The generated web app
+  builds and passes SQLite-backed REST create/read plus runtime facts, but its stale
+  `[0.20.0,0.21.0)` references emit NU1603 because the first published App/SQLite versions are
+  `0.20.4`.
+- The template source now uses standard `0.20.*` patch floats. An exact packed correction installed
+  in an isolated hive; both generated projects restored from NuGet.org without warnings, the web
+  project built cleanly, and the console passed SQLite Entity save/load/query.
+- A separate non-blocking startup-explanation rough edge remains: local SQLite fallback succeeds only
+  after logging a failed service-discovery correction. Keep it with the discovery/runtime owner.
 
 ## Remote/public state
 
@@ -71,11 +80,13 @@ Focused implementation evidence:
 
 ## Next actions
 
-1. Perform one focused public-feed consumer observation against the live 0.20 packages: restore the
-   documented first-use path from NuGet and record only concrete failures.
-2. Reconcile R12-05's pre-publication language with the completed minimal release; do not revive the
-   removed release compiler or full certification bureaucracy.
-3. Resume product and coherent public-documentation work. Do not expand release infrastructure.
+1. Commit the template-range correction and greenfield public-entry copy to `dev`; this publishes
+   nothing.
+2. Open a pull request to `main` for ordinary validation. Merge only when publishing the corrected
+   template and docs is intended.
+3. After that main-boundary publication, repeat only the clean public template restore and record the
+   result; then address the separate SQLite discovery/explanation rough edge.
+4. Resume product and coherent public-documentation work. Do not expand release infrastructure.
 
 ## Repository boundaries
 

--- a/docs/initiatives/koan-v1/work-items/r12/R12-05-public-consumer-journey.md
+++ b/docs/initiatives/koan-v1/work-items/r12/R12-05-public-consumer-journey.md
@@ -9,16 +9,16 @@ framework_version: v0.20.0
 validation:
   date_last_tested: 2026-07-20
   status: in-progress
-  scope: pre-freeze convergence complete; exact candidate commit and certification pending
+  scope: public-feed template journey works; clean-restore correction pending
 ---
 
 # R12-05 — Freeze and certify the first 0.20 candidate
 
 - Tranche: `T7B — public product maturity`
-- Status: `in-progress — pre-freeze convergence complete; exact candidate not yet frozen`
+- Status: `in-progress — public-feed journey works; clean-restore correction pending`
 - Depends on: passed R12-01 through R12-04
 - Unlocks: R12-06 publication and genuine public-feed consumer observation
-- Owner: the existing release compiler owns exact selection, versions, proof, artifacts, and local escrow
+- Owner: the shipped template source owns the package-first consumer expression; standard NuGet owns resolution
 
 ## Meaningful outcome
 
@@ -28,6 +28,87 @@ templates, FirstUse, GoldenJourney, and recovery evidence pass locally before an
 
 This is release-candidate engineering evidence, not public-consumer evidence. An isolated local feed can
 prove exact package behavior; only packages visible on NuGet can prove the public experience.
+
+## Public-feed observation checkpoint — 2026-07-21
+
+**Task:** Remove the warning from the live template journey and replace pre-publication copy with the
+current NuGet path.
+
+**Application intent:** A new developer installs Koan, generates an application, and receives the
+latest compatible 0.20 fixes with a clean restore.
+
+**Public expression:** `dotnet new install Sylin.Koan.Templates`, `dotnet new koan-web -o TodoApi`,
+and `dotnet run`. Generated Koan references use standard NuGet `0.20.*` patch-floating versions.
+
+**Guarantee/correction:** NuGet selects the latest available 0.20 patch and cannot cross into 0.21.
+If no 0.20 package exists, restore fails honestly; it does not approximate a nonexistent `0.20.0`
+lower bound with NU1603 warnings.
+
+**Complete intent surface:** No additional command, Koan API, decoration, configuration, context, or
+runtime prerequisite exists beyond the public expression.
+
+**Public concepts:** Only NuGet's standard floating patch version, which expresses “latest compatible
+fix within the supported 0.20 line.”
+
+**Docs read:** `docs/engineering/index.md` requires ordinary packaging and focused validation;
+`docs/architecture/principles.md` requires standard .NET and one current path; `README.md`,
+`docs/index.md`, `docs/getting-started/quickstart.md`, `docs/getting-started/overview.md`, and the
+template companions own the public entry but still describe publication as pending; ARCH-0110 keeps
+publication exclusively on the resulting `main` push.
+
+**Code read:** `templates/Sylin.Koan.Templates.csproj` is the content-only package owner;
+`templates/koan-web/KoanWebApp.csproj` and `templates/koan-console/KoanConsoleApp.csproj` contain the
+four stale ranges; `templates/Directory.Build.props` and `.targets` deliberately prevent hidden
+rewrite machinery; the template programs/models/controllers already express the intended four-line
+host and Entity-first application.
+
+**Reusing:** The existing content-only template pack, public 0.20 packages, standard NuGet resolution,
+the four-line `AddKoan()` host, `Entity<T>`, `EntityController<T>`, and SQLite's autonomous local
+default.
+
+**Creating new:** None. The shipped template source and its current public documentation are the
+existing owners.
+
+**Coalescence:** The closest pattern is the four direct template `PackageReference` entries. Keep the
+content-only package architecture; replace their stale bounded literals at the template source and
+delete pending-publication language. A release tool, token replacement phase, central version
+constant, Koan abstraction, or generated-app correction would add a second owner.
+
+**Ergonomics:** The developer still learns three ordinary .NET commands and no version choice. The
+generated project remains immediately readable in an IDE; `0.20.*` visibly communicates the patch
+policy without a Koan-specific concept or restore warning.
+
+**Constraints satisfied:** Business intent leads; standard .NET/NuGet owns the behavior; no runtime,
+data, controller, Entity, provider, options, constants, DTO, or shared-contract change exists; the
+controller-only and Entity-first guardrails remain intact; documentation becomes instruction-first
+and current; validation is limited to isolated public-feed install/generate/restore/build/runtime
+proofs.
+
+**Risks:** Floating restore is intentionally variable within the compatible 0.20 line. An application
+that requires exact reproducibility can use ordinary NuGet locking; the beginner template optimizes
+for receiving current fixes. The public feed may be eventually consistent immediately after a future
+publication.
+
+**Observed before correction:** `Sylin.Koan.Templates 0.20.5` installed and generated successfully.
+The web template restored and built against `Sylin.Koan.App 0.20.4` and
+`Sylin.Koan.Data.Connector.Sqlite 0.20.4`; REST create/read, SQLite persistence, and Koan facts passed.
+Both direct references emitted NU1603 because `[0.20.0,0.21.0)` names an unpublished minimum. A
+temporary `0.20.*` substitution restored cleanly and resolved both packages to `0.20.4`.
+
+**Focused correction evidence:** The corrected content-only template packed successfully. An isolated
+custom hive installed that exact nupkg and generated both public short names. Both generated projects
+contained only `0.20.*` Koan references and restored from NuGet.org with no warning. The web project
+built with zero warnings/errors. The console project selected local SQLite and passed Entity
+save/load/query. The earlier live web host passed SQLite-backed REST create/read and
+`/.well-known/Koan/facts`. No full release ratchet was run.
+
+**Separate observed rough edge:** SQLite's zero-configuration local fallback works, but startup first
+reports failed service discovery and a corrective endpoint diagnostic before selecting
+`.koan/data/Koan.sqlite`. This is not a template or persistence failure; it is a distinct startup
+explanation/delight issue for the discovery owner and is not folded into this package-range correction.
+
+This checkpoint supersedes the pre-publication release-compiler mechanics below. Those mechanisms
+were subsequently removed; R12-06 records the minimal successful main-boundary publication.
 
 ## Architecture checkpoint — one frozen local candidate
 

--- a/docs/initiatives/koan-v1/work-items/r12/R12-06-publish-and-observe-first-wave.md
+++ b/docs/initiatives/koan-v1/work-items/r12/R12-06-publish-and-observe-first-wave.md
@@ -201,7 +201,7 @@ release compiler.
 and receive generated projects compatible with the guaranteed Koan 0.20 family.
 
 **Public expression:** Generated projects contain ordinary bounded NuGet `PackageReference` versions
-`[0.20.0,0.21.0)`.
+`0.20.*`, selecting the latest compatible fix without crossing into 0.21.
 
 **Guarantee/correction:** NuGet resolves an available compatible 0.20 package and rejects 0.21 or
 later. Template packing fails only for ordinary MSBuild/NuGet errors, not because a Koan-only compiler

--- a/docs/initiatives/koan-v1/work-items/r12/R12-06-publish-and-observe-first-wave.md
+++ b/docs/initiatives/koan-v1/work-items/r12/R12-06-publish-and-observe-first-wave.md
@@ -1,8 +1,8 @@
 ---
 type: WORK
 domain: release
-status: active
-last_updated: 2026-07-20
+status: completed
+last_updated: 2026-07-21
 framework_version: v0.20.0
 ---
 
@@ -172,12 +172,25 @@ safe because the compiler already proves exact equivalence between supported own
 each selected identity, and fails with the exact missing/ambiguous artifact rather than publishing a
 lower-maturity package.
 
-**Observed external ownership:** The guaranteed closure contains 38 IDs. At observation time, 18
-existing packages were owned by `sylin-labs`, 17 IDs did not yet exist, two existing packages were
-owned by `sylin.org`, and one package page did not return a stable owner result. The current key
-successfully created `Sylin.Koan 0.20.4` but cannot update the old-owner packages. Repository selection
-is corrected independently; ownership transfer or an appropriately authorized credential remains a
-NuGet account prerequisite, not release code.
+**Resolved external ownership:** The guaranteed closure contains 38 IDs. The historical ownership
+split was resolved without adding release code: all 166 indexed package identities owned by
+`sylin-labs` were preserved under `sylin.org`, and the old organization was deleted after its package
+count reached zero. The authenticated account reports `sylin.org` as its sole organization with 240
+packages. No package was deleted or unlisted; NuGet's public owner index may lag the authoritative
+account state.
+
+## Publication evidence — 2026-07-21
+
+- PR `#93` merged `dev` to `main` with merge commit
+  `ad9d739199da809fa44efc9a4ce3db8059348b42`, preserving version history.
+- `Release packages` run `29792486934` completed successfully in one job.
+- Product-surface resolution, packing, and NuGet publication all passed for the exact 38-package
+  guaranteed 0.20 closure; non-guaranteed packages were not selected.
+- `dev` pushes remained inert. No workstation publication, tag, GitHub Release, lineage branch,
+  escrow, or remote release configuration participated.
+- The first failed main run remains useful historical evidence: it published `Sylin.Koan 0.20.4`,
+  then proved why blind all-package publication was incorrect. The successful run validates the
+  corrected product-surface chokepoint.
 
 ## Standard template-pack checkpoint — 2026-07-20
 
@@ -209,8 +222,8 @@ it ships; release tooling is too broad and generated applications are too late.
 0.21 template deliberately changes its visible ranges and receives a new template identity through
 its existing local NBGV owner.
 
-## Authorization boundary
+## Completed boundary
 
-The maintainer authorized redesign and local implementation. Commit the correction to `dev`, where it
-triggers nothing. Do not update `main`, publish from a workstation, create a tag/Release, or change
-remote configuration while validating this correction; merging to `main` is the publication action.
+The correction was committed to `dev`, validated by PR `#93`, and published only by the resulting
+`main` commit. Future `dev` work remains inert; every future `main` commit remains an intentional
+publication event.

--- a/templates/README.md
+++ b/templates/README.md
@@ -3,15 +3,14 @@
 Two `dotnet new` paths to a persisted Koan Entity application. The templates choose a proved package family; the
 generated application contains business code and ordinary .NET structure, not framework scaffolding.
 
-## Install after publication
+## Install from NuGet
 
 ```powershell
 dotnet new install Sylin.Koan.Templates
 ```
 
-This becomes the canonical Koan 0.20 preview entry after the first wave is visible on NuGet. Until then, run
-`dotnet run --project samples/FirstUse` from the repository checkout. Release validation already runs this template
-command against the exact locally compiled candidate, but local candidate evidence is not public availability.
+This is the canonical Koan 0.20 preview entry. The template package and its guaranteed dependencies are live on
+NuGet.
 
 ## First result
 
@@ -48,9 +47,9 @@ reference priority and uses `.koan/data/Koan.sqlite`; there is no generated `app
 schema script, repository, or version prompt. Add configuration only when the application intends to override a
 derived default.
 
-Each generated project carries an ordinary bounded NuGet range for the guaranteed 0.20 family:
-`[0.20.0,0.21.0)`. NuGet selects an available compatible 0.20 package and rejects a future breaking
-0.21 package. The application does not align Koan package versions itself.
+Each generated project uses the ordinary NuGet patch float `0.20.*`. NuGet selects the latest available
+compatible 0.20 fix and cannot cross into a future breaking 0.21 package. The application does not align
+independently versioned Koan packages itself.
 
 ## Inspectability and next steps
 

--- a/templates/TECHNICAL.md
+++ b/templates/TECHNICAL.md
@@ -8,9 +8,9 @@ the provider reference and SQLite's autonomous local target are sufficient inten
 
 ## Preparation and packing
 
-Template source contains its standard NuGet compatibility ranges directly. Both generated projects target
-`[0.20.0,0.21.0)`, which accepts the guaranteed 0.20 family and rejects a future breaking 0.21 family. The
-content-only project packs directly with `dotnet pack`; there is no preparation or token-replacement phase.
+Template source contains its standard NuGet patch policy directly. Generated Koan references use `0.20.*`, which
+selects the latest available fix in the guaranteed 0.20 family and cannot cross into a future breaking 0.21 family.
+The content-only project packs directly with `dotnet pack`; there is no preparation or token-replacement phase.
 
 The packed artifact must contain both canonical `.template.config/template.json` files, `README.md`, and the exact
 repository `icon.png`. It must contain no `bin`, `obj`, generated `appsettings.json`, unresolved token, runtime

--- a/templates/koan-console/KoanConsoleApp.csproj
+++ b/templates/koan-console/KoanConsoleApp.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sylin.Koan" Version="[0.20.0,0.21.0)" />
-    <PackageReference Include="Sylin.Koan.Data.Connector.Sqlite" Version="[0.20.0,0.21.0)" />
+    <PackageReference Include="Sylin.Koan" Version="0.20.*" />
+    <PackageReference Include="Sylin.Koan.Data.Connector.Sqlite" Version="0.20.*" />
   </ItemGroup>
 
 </Project>

--- a/templates/koan-web/KoanWebApp.csproj
+++ b/templates/koan-web/KoanWebApp.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sylin.Koan.App" Version="[0.20.0,0.21.0)" />
-    <PackageReference Include="Sylin.Koan.Data.Connector.Sqlite" Version="[0.20.0,0.21.0)" />
+    <PackageReference Include="Sylin.Koan.App" Version="0.20.*" />
+    <PackageReference Include="Sylin.Koan.Data.Connector.Sqlite" Version="0.20.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## What changed

- generate web and console templates with standard NuGet `0.20.*` patch floats
- make the live NuGet template path the canonical public entry
- record the focused public-feed observation and the separate SQLite startup-explanation finding

## Why

The published template restored successfully but emitted NU1603 because `[0.20.0,0.21.0)` names an unpublished minimum while the first App and SQLite packages are `0.20.4`. A patch float selects the latest compatible 0.20 fix without crossing into 0.21.

## Validation

- installed public `Sylin.Koan.Templates 0.20.5` in an isolated hive
- generated, restored, built, and ran the web path; SQLite REST create/read and runtime facts passed
- packed the corrected template and installed the exact nupkg in another isolated hive
- generated both `koan-web` and `koan-console`
- restored both against NuGet.org only with no warnings
- web build passed with zero warnings/errors
- console SQLite Entity save/load/query passed

Opening this PR validates only. NuGet publication occurs only if the PR is merged and the resulting commit reaches `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public NuGet-based quickstart using the `koan-web` template to generate and run a persisted Todo API.
  - Added instructions for creating and reading Todo items through `/api/todos`.
  - Added guidance for checking runtime facts through the documented endpoint.
  - Templates now receive compatible Koan 0.20 fixes automatically within the 0.20 release family.

- **Documentation**
  - Updated getting-started guides, templates documentation, and quickstart examples to reflect the publicly available installation workflow.
  - Clarified validation coverage and linked readers to the template guide and executable sample documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->