### PR TITLE
Record external auth API baselines

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -9,6 +9,9 @@
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == '' and '$(PackageId)' == 'Sylin.Koan.Media.Abstractions'">0.20.0</PackageValidationBaselineVersion>
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == '' and '$(PackageId)' == 'Sylin.Koan.Media.Core'">0.20.0</PackageValidationBaselineVersion>
     <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == '' and '$(PackageId)' == 'Sylin.Koan.Media.Web'">0.20.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == '' and '$(PackageId)' == 'Sylin.Koan.Web.Auth.Connector.Google'">0.20.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == '' and '$(PackageId)' == 'Sylin.Koan.Web.Auth.Connector.Microsoft'">0.20.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == '' and '$(PackageId)' == 'Sylin.Koan.Web.Auth.Connector.Discord'">0.20.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/docs/initiatives/koan-v1/NOW.md
+++ b/docs/initiatives/koan-v1/NOW.md
@@ -84,12 +84,14 @@ contract are separately supported while Cache Redis remains unassessed. R13-16 p
 staged and public consumers, product/API guards, lean coherence, and exact publication of its six owners.
 S3 and Data Backup are shelved; they are not 0.20 claims or blockers.
 
-The active slice is [R13-17](work-items/r13/R13-17-external-auth-promotion.md): promote Google,
-Microsoft, and Discord as definition-only integrations over the shared Web Auth runtime. The focused
-definition suite passes 41/41 and the existing deterministic OAuth2/OIDC authorization-code suite passes
-5/5 without live credentials. Exact packs, the staged package-only consumer, generated product truth,
-and API posture are green. Lean no-tests coherence passed all eight legs in 66.3 seconds; public
-observation remains.
+R13-17 is also complete: Google, Microsoft, and Discord are public at exact `0.20.0`, indexed, and
+public-consumer green. The focused definition suite passed 41/41 and the deterministic OAuth2/OIDC
+authorization-code suite passed 5/5 without live credentials. Release publication created only those
+three new identities; already-public Storage/Media packages were skipped at their existing versions.
+Their immutable API floors are now recorded centrally without touching package-owned version paths.
+
+The next R13 boundary is assessment of only the already-decided Agyo and Zen Garden ownership moves.
+No migration starts until its public destination evidence exists; this does not reopen S3 or Backup.
 Untracked `tmp/` is unrelated user-owned material and must remain untouched and unstaged.
 
 ## Remote/public state
@@ -143,6 +145,11 @@ Untracked `tmp/` is unrelated user-owned material and must remain untouched and 
   six Local Storage/Media owners at exact `0.20.0`. All six are indexed and the fresh NuGet.org-only
   consumer passed. S3 and Backup remained unchanged and unpublished. Attempt 1 encountered a transient
   NuGet lookup miss before packing; rerunning the failed job succeeded without a code change.
+- PR `#107` passed lean gate `29926425619`, squash-merged as
+  `a12b2154907d9f75f8bdef77cf4470ecefa1aad8`, and release run `29926734114` published Google,
+  Microsoft, and Discord Auth connectors at exact `0.20.0`. All three are indexed and the unchanged
+  fresh NuGet.org-only consumer passed. Existing Storage/Media packages remained at `0.20.0` and were
+  skipped as duplicates, proving central baseline capture did not create patch churn.
 - The historical `sylin-labs` NuGet organization is retired. Ownership of all 166 indexed historical
   Sora and Koan package IDs was preserved under `sylin.org`; the authenticated account reports one
   organization, `sylin.org`, with 240 packages. No packages were deleted or unlisted. Public owner
@@ -165,10 +172,10 @@ Untracked `tmp/` is unrelated user-owned material and must remain untouched and 
 
 ## Next actions
 
-1. Pass the lean coherence gate and publish the three external Auth connectors through the existing main boundary.
-2. Observe their exact accepted/indexed versions and rerun the same consumer from NuGet.org only.
-3. Record their immutable API floors centrally, without editing already-published package projects, then
-   assess only the remaining accepted migrations.
+1. Validate and land the central immutable API floors for the three now-public Auth connectors without
+   editing package-owned paths.
+2. Assess the already-decided Agyo and Zen Garden moves against actual public destination evidence.
+3. Retire or redirect Koan owners only when destination packages preserve the current behavior and consumers.
 
 ## Repository boundaries
 

--- a/docs/initiatives/koan-v1/PROGRESS.md
+++ b/docs/initiatives/koan-v1/PROGRESS.md
@@ -22,13 +22,12 @@ or completes a work item. The roadmap describes order; it does not report progre
 - Overall: `active`
 - Current tranche: `T8 — public provider promotion`
 - Active work item: [R13 — Promote the meaningful public surface to 0.20](work-items/R13-terminal-package-maturity.md)
-- Active child: [R13-17 — External authentication promotion](work-items/r13/R13-17-external-auth-promotion.md)
-- Most recently completed R13 child: [R13-16 — Local Storage/Media promotion](work-items/r13/R13-16-storage-backup-media-promotion.md)
+- Active child: none; the next boundary is evidence-based assessment of the accepted Agyo/Zen Garden migrations
+- Most recently completed R13 child: [R13-17 — External authentication promotion](work-items/r13/R13-17-external-auth-promotion.md)
 - Most recently completed child: [R12-06 — Publish the first 0.20 package wave](work-items/r12/R12-06-publish-and-observe-first-wave.md)
-- Pending release boundary: Google, Microsoft, and Discord Auth connectors; 46 focused deterministic
-  tests, exact packs, staged package consumer, product truth, and API posture are green. Lean no-tests
-  coherence passed all eight legs in 66.3 seconds; public observation remains.
-  S3 and Backup are shelved.
+- Pending release boundary: land the validated central immutable API floors for the three now-public Auth
+  connectors (`76/76` configured); this changes no package-owned path and therefore creates no new package
+  version. S3 and Backup are shelved.
 - Preview readiness: `technical GO`; R12-07's public upgrade, mixed-state publisher convergence, and
   feedback triage are complete; explicit maintainer go/no-go acceptance remains
 - Deliberate overlap: R12 remains `in-progress` only for
@@ -52,7 +51,7 @@ or completes a work item. The roadmap describes order; it does not report progre
 | R10 | [Graduate the golden sample portfolio](work-items/R10-golden-samples.md) | T7B | passed | R09; R08-04 | Codex · 2026-07-17 | All eleven children pass. Ten public applications build strictly; eight sample suites pass 45 with 2 intentional skips. Canon is automatic, CustomerCanon is graduated, and the portfolio no longer blocks package polish. |
 | R11 | [Graduate the NuGet product surface](work-items/R11-package-product-quality.md) | T7B | passed | R09; R10; guards R08-05 | Architect + Codex · 2026-07-19 | R11-01 through R11-07 pass. All 93 active packages have terminal topology, package-owned presentation, and zero objective findings; the complete public-release ratchet passed 4,648 tests with 30 intentional skips and no failures. |
 | R12 | [Road to the 0.20 Preview](work-items/R12-road-to-020-preview.md) | T7C | in-progress | R08 local evidence; R09; R10; R11 | Maintainer + Codex · 2026-07-22 | R12-01 through R12-06 are complete. R12-07 now has public before/after upgrade, mixed immutable-set publication convergence, and feedback triage evidence; its technical recommendation is GO and awaits explicit maintainer acceptance. |
-| R13 | [Promote the meaningful public surface to 0.20](work-items/R13-terminal-package-maturity.md) | T8 | in-progress | R11; R12-06; ARCH-0120 | Maintainer + Codex · 2026-07-22 | Entity, Vector/Search, AI, and Local Storage/Media are public, indexed, consumer-green, and baseline-captured. R13-17 promotes Google, Microsoft, and Discord Auth; S3 and Backup are shelved. |
+| R13 | [Promote the meaningful public surface to 0.20](work-items/R13-terminal-package-maturity.md) | T8 | in-progress | R11; R12-06; ARCH-0120 | Maintainer + Codex · 2026-07-22 | Entity through external Auth are public, indexed, consumer-green, and baseline-captured. Only evidence-based assessment of the accepted Agyo/Zen Garden migrations remains; S3 and Backup are shelved. |
 
 Allowed status values are `pending`, `in-progress`, `blocked`, `passed`, and `stopped`. Only one work
 item should normally be `in-progress`.
@@ -74,7 +73,7 @@ item should normally be `in-progress`.
 | R10 | passed | All eleven children pass. Ten public applications, their index/solution membership, current docs, and eight executable sample suites agree. |
 | R11 | passed | R11-01 through R11-07 pass. The 93-package graph, 26 claims, package-owned prose, objective zero-finding quality report, clean packs, focused family evidence, and complete public-release ratchet agree. |
 | R12 | in-progress | Technical evidence is complete: the public app upgraded from exact 0.20.4 packages to current 0.20.* packages with the same result, mixed-state publication converged, and feedback was triaged. Maintainer GO acceptance remains. |
-| R13 | in-progress | The first lean slice through R13-16 Local Storage/Media is public and observed. R13-17 owns only Google, Microsoft, and Discord Auth: 41/41 definition tests, 5/5 deterministic protocol tests, exact packs, staged package consumer, product truth, API posture, and the 66.3-second lean gate are green. S3 and Backup are shelved; public proof remains. |
+| R13 | in-progress | The first lean slice through R13-17 external Auth is public and observed. Google, Microsoft, and Discord passed 46 focused tests, exact/staged/public package proof, product/API posture, and lean coherence. The publisher created only their three `0.20.0` identities and skipped unchanged Storage/Media versions. Accepted migration assessment remains; S3 and Backup are shelved. |
 
 ## Divergence and risk log
 

--- a/docs/initiatives/koan-v1/work-items/R13-terminal-package-maturity.md
+++ b/docs/initiatives/koan-v1/work-items/R13-terminal-package-maturity.md
@@ -9,13 +9,13 @@ framework_version: v0.20.0
 validation:
   date_last_tested: 2026-07-22
   status: in-progress
-  scope: Entity through Local Storage/Media public and observed; external authentication promotion active
+  scope: Entity through external Auth public and observed; accepted migration assessment next
 ---
 
 # R13 — Promote the meaningful public surface to 0.20
 
 - Tranche: `T8 — public provider promotion`
-- Status: `in-progress — promote Google, Microsoft, and Discord authentication; S3 and Backup shelved`
+- Status: `in-progress — external Auth complete; assess accepted migrations; S3 and Backup shelved`
 - Depends on: passed R11, completed R12-06, and accepted
   [ARCH-0120](../../../decisions/ARCH-0120-terminal-package-maturity.md) with validation corrected by
   [ARCH-0121](../../../decisions/ARCH-0121-claim-scoped-validation.md)
@@ -139,10 +139,10 @@ of all six exact `0.20.0` artifacts, and the fresh NuGet.org-only consumer. Thei
 are recorded centrally in R13-17, so baseline capture does not mint behaviorless package patches. S3
 and Backup remain shelved.
 
-[R13-17](r13/R13-17-external-auth-promotion.md) is active. Google, Microsoft, and Discord are the
-exact three-owner boundary over the shared Web Auth runtime; deterministic definition/protocol tests,
-exact packs, the staged consumer, product truth, API posture, and the 66.3-second lean no-tests gate
-are green. Public observation remains.
+[R13-17](r13/R13-17-external-auth-promotion.md) passed through PR `#107`, main commit
+`a12b2154907d9f75f8bdef77cf4470ecefa1aad8`, release run `29926734114`, public indexing of all
+three exact `0.20.0` artifacts, and the unchanged fresh NuGet.org-only consumer. Its immutable API floors
+are recorded centrally in this closure change. Existing Storage/Media versions were skipped unchanged.
 
 ## Execution
 
@@ -169,7 +169,8 @@ Status: complete. The seven owners are public and the clean external consumer pa
 
 ### R13-C onward — Promote provider families
 
-Status: active through R13-17 external authentication promotion; S3 and Backup shelved.
+Status: complete through R13-17 external authentication promotion; accepted migration assessment next;
+S3 and Backup shelved.
 
 Open one short family card only when implementation begins. Each card freezes its guarantee and
 limits, names the existing conformance owner, identifies the real provider boundary, and ends with a

--- a/docs/initiatives/koan-v1/work-items/r13/R13-17-external-auth-promotion.md
+++ b/docs/initiatives/koan-v1/work-items/r13/R13-17-external-auth-promotion.md
@@ -3,12 +3,12 @@ type: SPEC
 domain: web
 title: "R13-17 - Promote external authentication connectors"
 audience: [architects, maintainers, developers, ai-agents]
-status: current
+status: resolved
 last_updated: 2026-07-22
 framework_version: v0.20.0
 validation:
   date_last_tested: 2026-07-22
-  status: in-progress
+  status: passed
   scope: Google, Microsoft, and Discord connector definitions, shared authorization-code runtime, packages, consumer, product, and API evidence
 ---
 
@@ -86,4 +86,13 @@ behaviorless patch packages. Existing project-local floors remain valid; later p
   immutable floors; only these three legitimate first publications are pending. The six R13-16 floors
   are active centrally without changing those package versions.
 - Lean no-tests coherence passed all eight legs in 66.3 seconds.
-- Remaining: main publication, public indexing, and the unchanged NuGet.org-only consumer.
+- PR `#107` passed lean gate `29926425619` and squash-merged as
+  `a12b2154907d9f75f8bdef77cf4470ecefa1aad8`.
+- Release run `29926734114` accepted exactly the three `0.20.0` connector packages and symbols. The
+  already-public Storage/Media identities remained at `0.20.0` and were skipped as duplicates; no
+  behaviorless patch packages were created.
+- NuGet.org indexed all three exact versions. The unchanged application restored from NuGet.org only
+  into an empty cache, built with 0 warnings/errors, loaded all three modules, elected Google, and emitted
+  `EXTERNAL-AUTH|PACKAGE-CONSUMER|ADDKOAN|GOOGLE|MICROSOFT|DISCORD|PASS`.
+- All three immutable API floors are now recorded centrally without editing their package-owned paths;
+  the focused guard reports `76/76 configured, 0 first-publication pending, 3 content-only`.


### PR DESCRIPTION
## Outcome

Closes R13-17 after public observation and records the three immutable external-Auth API floors centrally.

## Evidence

- PR #107 / main `a12b2154907d9f75f8bdef77cf4470ecefa1aad8`
- release run `29926734114` created exactly Google, Microsoft, and Discord `0.20.0` packages and symbols
- all three are indexed on NuGet.org
- empty-cache, NuGet.org-only consumer restored, built with 0 warnings/errors, loaded all three providers, elected Google, and passed
- focused API guard: `76/76 configured, 0 first-publication pending, 3 content-only`

## Version behavior

This PR changes `Directory.Build.targets` and evidence docs only. It touches no package-owned NBGV path, so it creates no new package version; the main publisher should skip the existing package identities unchanged.

S3 and Backup remain shelved.