### PR TITLE
Close the 0.20 package promotion epic

### DIFF
--- a/docs/initiatives/koan-v1/NOW.md
+++ b/docs/initiatives/koan-v1/NOW.md
@@ -90,8 +90,13 @@ authorization-code suite passed 5/5 without live credentials. Release publicatio
 three new identities; already-public Storage/Media packages were skipped at their existing versions.
 Their immutable API floors are now recorded centrally without touching package-owned version paths.
 
-The next R13 boundary is assessment of only the already-decided Agyo and Zen Garden ownership moves.
-No migration starts until its public destination evidence exists; this does not reopen S3 or Backup.
+R13 is complete. [R13-18](work-items/r13/R13-18-accepted-migration-disposition.md) rechecked the
+already-decided Agyo and Zen Garden moves against their public repositories and NuGet.org. Agyo has no
+public package IDs or migrated Agents/Orchestration/Eval/Review owners; Zen Garden has no newer public
+tip or equivalent Models/HuggingFace lifecycle proof. The six departing Koan owners therefore remain at
+truthful `0.17` intent with no supported claim until ARCH-0089's cross-repository destination gate is met.
+No migration, deletion, promotion, or forwarding package is part of R13 closure. This does not reopen
+S3 or Backup.
 Untracked `tmp/` is unrelated user-owned material and must remain untouched and unstaged.
 
 ## Remote/public state
@@ -150,6 +155,10 @@ Untracked `tmp/` is unrelated user-owned material and must remain untouched and 
   Microsoft, and Discord Auth connectors at exact `0.20.0`. All three are indexed and the unchanged
   fresh NuGet.org-only consumer passed. Existing Storage/Media packages remained at `0.20.0` and were
   skipped as duplicates, proving central baseline capture did not create patch churn.
+- PR `#108` passed lean gate `29927889388`, squash-merged as
+  `138388e86eacad2c9c9b238e97548a465396f2a4`, and release run `29928202945` reported `76/76`
+  immutable API floors. Every packed identity already existed; NuGet returned zero new package or
+  symbol-package creations.
 - The historical `sylin-labs` NuGet organization is retired. Ownership of all 166 indexed historical
   Sora and Koan package IDs was preserved under `sylin.org`; the authenticated account reports one
   organization, `sylin.org`, with 240 packages. No packages were deleted or unlisted. Public owner
@@ -172,10 +181,9 @@ Untracked `tmp/` is unrelated user-owned material and must remain untouched and 
 
 ## Next actions
 
-1. Validate and land the central immutable API floors for the three now-public Auth connectors without
-   editing package-owned paths.
-2. Assess the already-decided Agyo and Zen Garden moves against actual public destination evidence.
-3. Retire or redirect Koan owners only when destination packages preserve the current behavior and consumers.
+1. Obtain explicit maintainer acceptance or rejection of R12-07's technical GO recommendation.
+2. Resume ARCH-0089 migrations only from public Agyo/Zen Garden destination and consumer evidence.
+3. Keep S3, Backup, and unclaimed `0.17` migration owners outside the supported 0.20 surface.
 
 ## Repository boundaries
 

--- a/docs/initiatives/koan-v1/PROGRESS.md
+++ b/docs/initiatives/koan-v1/PROGRESS.md
@@ -9,7 +9,7 @@ framework_version: v0.20.0
 validation:
   date_last_tested: 2026-07-22
   status: in-progress
-  scope: Entity, Vector/Search, and AI providers public and observed; Local Storage/Media promotion active
+  scope: R13 public provider promotion passed; R12-07 technical GO awaits maintainer acceptance
 ---
 
 # Koan V1 Reorganization Progress
@@ -20,14 +20,13 @@ or completes a work item. The roadmap describes order; it does not report progre
 ## Initiative state
 
 - Overall: `active`
-- Current tranche: `T8 — public provider promotion`
-- Active work item: [R13 — Promote the meaningful public surface to 0.20](work-items/R13-terminal-package-maturity.md)
-- Active child: none; the next boundary is evidence-based assessment of the accepted Agyo/Zen Garden migrations
-- Most recently completed R13 child: [R13-17 — External authentication promotion](work-items/r13/R13-17-external-auth-promotion.md)
-- Most recently completed child: [R12-06 — Publish the first 0.20 package wave](work-items/r12/R12-06-publish-and-observe-first-wave.md)
-- Pending release boundary: land the validated central immutable API floors for the three now-public Auth
-  connectors (`76/76` configured); this changes no package-owned path and therefore creates no new package
-  version. S3 and Backup are shelved.
+- Current tranche: `T7C — preview acceptance`
+- Active work item: [R12 — Road to the 0.20 Preview](work-items/R12-road-to-020-preview.md)
+- Active child: [R12-07 — Preview evolution](work-items/r12/R12-07-preview-evolution.md)
+- Most recently completed R13 child: [R13-18 — Accepted migration disposition](work-items/r13/R13-18-accepted-migration-disposition.md)
+- Most recently completed child: [R13 — Promote the meaningful public surface to 0.20](work-items/R13-terminal-package-maturity.md)
+- Pending release boundary: none. R13 is complete; S3 and Backup are shelved. R12-07 awaits explicit
+  maintainer acceptance of its technical GO recommendation.
 - Preview readiness: `technical GO`; R12-07's public upgrade, mixed-state publisher convergence, and
   feedback triage are complete; explicit maintainer go/no-go acceptance remains
 - Deliberate overlap: R12 remains `in-progress` only for
@@ -51,7 +50,7 @@ or completes a work item. The roadmap describes order; it does not report progre
 | R10 | [Graduate the golden sample portfolio](work-items/R10-golden-samples.md) | T7B | passed | R09; R08-04 | Codex · 2026-07-17 | All eleven children pass. Ten public applications build strictly; eight sample suites pass 45 with 2 intentional skips. Canon is automatic, CustomerCanon is graduated, and the portfolio no longer blocks package polish. |
 | R11 | [Graduate the NuGet product surface](work-items/R11-package-product-quality.md) | T7B | passed | R09; R10; guards R08-05 | Architect + Codex · 2026-07-19 | R11-01 through R11-07 pass. All 93 active packages have terminal topology, package-owned presentation, and zero objective findings; the complete public-release ratchet passed 4,648 tests with 30 intentional skips and no failures. |
 | R12 | [Road to the 0.20 Preview](work-items/R12-road-to-020-preview.md) | T7C | in-progress | R08 local evidence; R09; R10; R11 | Maintainer + Codex · 2026-07-22 | R12-01 through R12-06 are complete. R12-07 now has public before/after upgrade, mixed immutable-set publication convergence, and feedback triage evidence; its technical recommendation is GO and awaits explicit maintainer acceptance. |
-| R13 | [Promote the meaningful public surface to 0.20](work-items/R13-terminal-package-maturity.md) | T8 | in-progress | R11; R12-06; ARCH-0120 | Maintainer + Codex · 2026-07-22 | Entity through external Auth are public, indexed, consumer-green, and baseline-captured. Only evidence-based assessment of the accepted Agyo/Zen Garden migrations remains; S3 and Backup are shelved. |
+| R13 | [Promote the meaningful public surface to 0.20](work-items/R13-terminal-package-maturity.md) | T8 | passed | R11; R12-06; ARCH-0120 | Maintainer + Codex · 2026-07-22 | Entity through external Auth are public, indexed, consumer-green, and baseline-captured. R13-18 keeps unready cross-repository migrations truthful at 0.17 without blocking closure; S3 and Backup are shelved. |
 
 Allowed status values are `pending`, `in-progress`, `blocked`, `passed`, and `stopped`. Only one work
 item should normally be `in-progress`.
@@ -73,12 +72,13 @@ item should normally be `in-progress`.
 | R10 | passed | All eleven children pass. Ten public applications, their index/solution membership, current docs, and eight executable sample suites agree. |
 | R11 | passed | R11-01 through R11-07 pass. The 93-package graph, 26 claims, package-owned prose, objective zero-finding quality report, clean packs, focused family evidence, and complete public-release ratchet agree. |
 | R12 | in-progress | Technical evidence is complete: the public app upgraded from exact 0.20.4 packages to current 0.20.* packages with the same result, mixed-state publication converged, and feedback was triaged. Maintainer GO acceptance remains. |
-| R13 | in-progress | The first lean slice through R13-17 external Auth is public and observed. Google, Microsoft, and Discord passed 46 focused tests, exact/staged/public package proof, product/API posture, and lean coherence. The publisher created only their three `0.20.0` identities and skipped unchanged Storage/Media versions. Accepted migration assessment remains; S3 and Backup are shelved. |
+| R13 | passed | Entity, Vector/Search, AI runtime/providers, Local Storage/Media, and external Auth are public, indexed, public-consumer green, and API-baseline complete. R13-18 found no public destination evidence for the accepted Agyo/Zen Garden moves, so six unclaimed owners remain truthfully at 0.17 under ARCH-0089 rather than being deleted or promoted. S3 and Backup are shelved. |
 
 ## Divergence and risk log
 
 | Date | Item | Observation | Disposition |
 |---|---|---|---|
+| 2026-07-22 | R13 accepted migration disposition | Agyo's public tip contains substantial RAG but no migrated Agents/Orchestration loop, standalone Eval/Review projects, or public NuGet package IDs. Zen Garden's public tip has not advanced since April and does not prove the complete Models/HuggingFace lifecycle destination. | Apply ARCH-0089's transition gate: keep the six departing Koan owners unclaimed at 0.17; perform no deletion, promotion, forwarding package, or sibling mutation. Move the cross-repository work out of the completed 0.20 promotion epic and resume only from public destination/consumer evidence. |
 | 2026-07-22 | Practical merge and publication flow | Per-package NBGV versioning and main publication had become coupled to a 107-project certification ratchet, a permanent PR-native job, a duplicate surface workflow, and repeated consumer proof. This delayed framework work while proving unrelated providers and confused portfolio certification with package identity. | ARCH-0121 keeps one cheap main-PR coherence job and one test-free main publisher. Affected behavior/native tests run during development; clean consumers apply only to first publication or changed artifact shape; the complete ratchet is an explicit whole-framework milestone. The exact replacement flow passed in 86.6 seconds versus about 16 minutes 22 seconds for the preceding connected gate. |
 | 2026-07-21 | R13 first-slice merge ratchet | The first simplified PR ratchet passed build, docs, product truth, API posture, and direct native proof, but its deterministic test leg exposed three real evidence seams: failed-start cleanup masked corrective exceptions, the shared Mongo Web bridge changed the database without preserving authentication source, and the clean consumer omitted locally newer package dependencies. | Keep the lean path and repair each direct owner. Dispose incomplete hosts without an invalid stop sequence; preserve an authenticated Mongo URL's original auth database; derive and pack the promoted owners' complete public project-reference closure through the existing repository inspector. Focused host/Communication/Data and real Mongo evidence pass; rerun the final PR ratchet. |
 | 2026-07-21 | ARCH-0120 value-led correction | The fixed 55-owner program confused repository accounting with product value. Provider adapters are legitimate public leaf packages whose consumers are applications; reverse dependencies cannot decide whether they belong. The ten-wave plan, terminal certificate, central exact-cell metadata, and generic admission/native-candidate coordination added more process than the 0.20 promotion decision required. | Amend ARCH-0120 and R13 around cohesive provider families. Product intent decides inclusion; shared semantics, provider-specific real-boundary proof, a clean consumer, and package/API integrity decide promotion. Preserve the claim/version/dependency invariant, API baselines, generated truth, and existing family tests. Keep PR #95 draft until superseded machinery is removed and the smaller slice is revalidated. |

--- a/docs/initiatives/koan-v1/work-items/R13-terminal-package-maturity.md
+++ b/docs/initiatives/koan-v1/work-items/R13-terminal-package-maturity.md
@@ -3,19 +3,19 @@ type: SPEC
 domain: framework
 title: "R13 - Promote the Meaningful Public Surface to 0.20"
 audience: [architects, maintainers, developers, ai-agents]
-status: current
+status: resolved
 last_updated: 2026-07-22
 framework_version: v0.20.0
 validation:
   date_last_tested: 2026-07-22
-  status: in-progress
-  scope: Entity through external Auth public and observed; accepted migration assessment next
+  status: passed
+  scope: Intended public provider families observed; accepted migrations dispositioned without unsafe retirement
 ---
 
 # R13 — Promote the meaningful public surface to 0.20
 
 - Tranche: `T8 — public provider promotion`
-- Status: `in-progress — external Auth complete; assess accepted migrations; S3 and Backup shelved`
+- Status: `passed — intended 0.20 families public; migrations dispositioned; S3 and Backup shelved`
 - Depends on: passed R11, completed R12-06, and accepted
   [ARCH-0120](../../../decisions/ARCH-0120-terminal-package-maturity.md) with validation corrected by
   [ARCH-0121](../../../decisions/ARCH-0121-claim-scoped-validation.md)
@@ -142,7 +142,15 @@ and Backup remain shelved.
 [R13-17](r13/R13-17-external-auth-promotion.md) passed through PR `#107`, main commit
 `a12b2154907d9f75f8bdef77cf4470ecefa1aad8`, release run `29926734114`, public indexing of all
 three exact `0.20.0` artifacts, and the unchanged fresh NuGet.org-only consumer. Its immutable API floors
-are recorded centrally in this closure change. Existing Storage/Media versions were skipped unchanged.
+were recorded centrally through PR `#108`, main commit
+`138388e86eacad2c9c9b238e97548a465396f2a4`, and release run `29928202945`. The guard reported
+`76/76` floors, every packed identity already existed, and no new package or symbol package was created.
+
+[R13-18](r13/R13-18-accepted-migration-disposition.md) passed by applying ARCH-0089's existing
+transition gate to current public evidence. Agyo has no public destination packages or migrated
+Agents/Orchestration/Eval/Review owners; Zen Garden has no newer public tip or complete
+Models/HuggingFace lifecycle proof. The six departing Koan owners remain unclaimed at `0.17`; no
+unsafe deletion, promotion, forwarding package, or sibling mutation occurred.
 
 ## Execution
 
@@ -169,8 +177,7 @@ Status: complete. The seven owners are public and the clean external consumer pa
 
 ### R13-C onward — Promote provider families
 
-Status: complete through R13-17 external authentication promotion; accepted migration assessment next;
-S3 and Backup shelved.
+Status: complete through R13-18 accepted migration disposition; S3 and Backup shelved.
 
 Open one short family card only when implementation begins. Each card freezes its guarantee and
 limits, names the existing conformance owner, identifies the real provider boundary, and ends with a

--- a/docs/initiatives/koan-v1/work-items/r13/R13-18-accepted-migration-disposition.md
+++ b/docs/initiatives/koan-v1/work-items/r13/R13-18-accepted-migration-disposition.md
@@ -1,0 +1,71 @@
+---
+type: SPEC
+domain: framework
+title: "R13-18 - Dispose accepted cross-repository migrations"
+audience: [architects, maintainers, developers, ai-agents]
+status: resolved
+last_updated: 2026-07-22
+framework_version: v0.20.0
+validation:
+  date_last_tested: 2026-07-22
+  status: passed
+  scope: Public Agyo and Zen Garden destination evidence, Koan ownership/version/claim posture, and transition-safe disposition
+---
+
+# R13-18 — Dispose accepted cross-repository migrations
+
+## Decision
+
+Close R13 without retiring the remaining Koan AI vertical. The accepted Agyo and Zen Garden ownership
+moves remain valid, but their destination-evidence gate is not met. They continue under the cross-repository
+program owned by [ARCH-0089](../../../../decisions/ARCH-0089-ai-pillar-dissolution.md), not as unfinished
+0.20 package-promotion work.
+
+This is a transition-safe disposition, not a reversal of ownership:
+
+- do not promote the departing Koan owners to `0.20`;
+- do not delete behavior before an equivalent destination and consumer exist;
+- do not create forwarding packages or make Koan depend upward on Agyo or Zen Garden;
+- resume from public destination evidence, not another Koan-side assessment.
+
+## Public destination evidence
+
+### Agyo
+
+Read-only inspection of public `sylin-org/agyo-tools` default branch `dev` at
+`5a202843ea36dc25c701c4b8812129c32cbb7138` (2026-06-21) found:
+
+- `Agyo.Rag`, `Agyo.Rag.Abstractions`, and their focused RAG suite exist;
+- RAG contains retrieval evaluation helpers, but no migrated Koan ReAct agent/tool loop or typed
+  Orchestration chain owner;
+- no standalone Eval or Review project exists;
+- NuGet.org contains no package with `Agyo` in its ID, and the intended `Sylin.Agyo.Rag`,
+  `Sylin.Agyo.Rag.Abstractions`, `Sylin.Agyo.Eval`, and `Sylin.Agyo.Review` IDs are absent.
+
+Therefore Agents/Orchestration, Eval, and Review have no public destination package or consumer proof.
+
+### Zen Garden
+
+Read-only inspection of public `sylin-org/zen-garden` default branch `dev` at
+`3f8885ffd876cbfc557181db560bb0b6f14c9790` (2026-04-18) found substantial resource inventory,
+AI routing/catalog, provider, and model-import mechanics. That public tip predates ARCH-0089 and has not
+advanced since the R11 handoff assessment. It contains no Hugging Face destination path and no newer
+evidence preserving Koan Models' complete pull/convert/quantize/deploy/version behavior and consumer.
+
+Therefore Models and Hugging Face still fail the accepted destination-equivalence gate.
+
+## Koan disposition
+
+`Sylin.Koan.AI.Agents`, `Sylin.Koan.AI.Orchestration`, `Sylin.Koan.AI.Eval`,
+`Sylin.Koan.AI.Review`, `Sylin.Koan.AI.Models`, and `Sylin.Koan.AI.Connector.HuggingFace` remain at
+truthful `0.17` intent with no supported product claim. They are neither promoted nor removed.
+
+The already-completed local retirements—Training, the legacy Zen Garden connector, and the false Compute
+surface—remain retired. No source, package, version, claim, workflow, or sibling repository changes are
+required by this disposition.
+
+## R13 consequence
+
+R13's intended public provider families are published, indexed, public-consumer green, and API-baseline
+complete. The cross-repository moves have now received their required evidence-based disposition without
+holding the 0.20 promotion epic open. S3 and Backup remain shelved and outside this result.


### PR DESCRIPTION
## Outcome

Closes R13 after all intended public provider families have been published and applies the accepted cross-repository transition gate without unsafe deletion.

## Migration disposition

- public Agyo `dev` tip `5a202843ea36dc25c701c4b8812129c32cbb7138` has substantial RAG, but no migrated Agents/Orchestration owner, standalone Eval/Review projects, or public Agyo NuGet IDs
- public Zen Garden `dev` tip `3f8885ffd876cbfc557181db560bb0b6f14c9790` has resource/catalog/routing/import mechanics but no newer complete Models/HuggingFace destination proof
- the six departing Koan owners remain unclaimed at truthful `0.17`; none are promoted or deleted
- ARCH-0089 remains the owner of future cross-repository work
- S3 and Backup remain shelved

## Validation

- docs lint: 0 errors (existing warning baseline only)
- public documentation truth: pass
- diff: four documentation files only; no source, claims, package, version, or workflow changes

R12-07's technical GO remains the only active epic decision and still requires explicit maintainer acceptance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Koan V1 progress records to mark R13 as completed and migration disposition as resolved.
  * Documented the accepted cross-repository migration decision and validation results.
  * Clarified that remaining Koan assets stay at 0.17 intent without supported 0.20 claims.
  * Added updated next steps, boundaries, and public release-state details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->