### PR TITLE
docs: accept the 0.20 preview GO

### DIFF
--- a/docs/initiatives/koan-v1/NOW.md
+++ b/docs/initiatives/koan-v1/NOW.md
@@ -1,7 +1,7 @@
 ---
 type: HANDOFF
 domain: koan-v1
-status: active
+status: resolved
 last_updated: 2026-07-22
 framework_version: v0.20.0
 ---
@@ -10,10 +10,9 @@ framework_version: v0.20.0
 
 ## Current objective
 
-Complete the 0.20 maturity cycle by promoting the maintainer-intended provider families through
-small, evidence-backed slices while preserving 0.20 as the supported-contract signal. Historical
-package counts do not define completion. Release automation is infrastructure, not a product
-capability, and must remain proportionate.
+The 0.20 maturity cycle is complete. Preserve 0.20 as the supported-contract signal, keep release
+automation proportionate, and return to ordinary value-led framework development. Historical package
+counts do not define completion.
 
 ## Completed baseline: first supported wave and public consumer proof
 
@@ -75,8 +74,9 @@ connects them.
 ## Exact pause point
 
 The lean process change and first seven-owner slice are merged, published, indexed, and public-consumer
-green. R12-07's ordinary public upgrade proof is also green; its GO recommendation awaits explicit
-maintainer acceptance rather than another technical exercise.
+green. R12-07's ordinary public upgrade proof is also green, and the maintainer explicitly accepted
+its GO recommendation on 2026-07-22. R12 and R13 are complete. This records 0.20 preview maturity; it
+does not declare V1 GA or a V1 support date.
 
 PostgreSQL R13-07 through Local Storage/Media R13-16 are merged, published, indexed, public-consumer
 green, and baseline-captured at their exact first 0.20 versions. Redis's functional backend and inert
@@ -181,7 +181,9 @@ Untracked `tmp/` is unrelated user-owned material and must remain untouched and 
 
 ## Next actions
 
-1. Obtain explicit maintainer acceptance or rejection of R12-07's technical GO recommendation.
+No active initiative work remains.
+
+1. Return to ordinary value-led framework development outside the closed maturity epics.
 2. Resume ARCH-0089 migrations only from public Agyo/Zen Garden destination and consumer evidence.
 3. Keep S3, Backup, and unclaimed `0.17` migration owners outside the supported 0.20 surface.
 

--- a/docs/initiatives/koan-v1/PROGRESS.md
+++ b/docs/initiatives/koan-v1/PROGRESS.md
@@ -3,13 +3,13 @@ type: ARCHITECTURE
 domain: framework
 title: "Koan V1 Reorganization Progress"
 audience: [architects, maintainers, ai-agents]
-status: current
+status: resolved
 last_updated: 2026-07-22
 framework_version: v0.20.0
 validation:
   date_last_tested: 2026-07-22
-  status: in-progress
-  scope: R13 public provider promotion passed; R12-07 technical GO awaits maintainer acceptance
+  status: passed
+  scope: R00-R13 terminal; R12 preview GO accepted and R13 provider promotion passed
 ---
 
 # Koan V1 Reorganization Progress
@@ -19,19 +19,17 @@ or completes a work item. The roadmap describes order; it does not report progre
 
 ## Initiative state
 
-- Overall: `active`
-- Current tranche: `T7C — preview acceptance`
-- Active work item: [R12 — Road to the 0.20 Preview](work-items/R12-road-to-020-preview.md)
-- Active child: [R12-07 — Preview evolution](work-items/r12/R12-07-preview-evolution.md)
+- Overall: `complete`
+- Current tranche: `complete — 0.20 preview maturity`
+- Active work item: none
+- Active child: none
 - Most recently completed R13 child: [R13-18 — Accepted migration disposition](work-items/r13/R13-18-accepted-migration-disposition.md)
-- Most recently completed child: [R13 — Promote the meaningful public surface to 0.20](work-items/R13-terminal-package-maturity.md)
-- Pending release boundary: none. R13 is complete; S3 and Backup are shelved. R12-07 awaits explicit
-  maintainer acceptance of its technical GO recommendation.
-- Preview readiness: `technical GO`; R12-07's public upgrade, mixed-state publisher convergence, and
-  feedback triage are complete; explicit maintainer go/no-go acceptance remains
-- Deliberate overlap: R12 remains `in-progress` only for
-  [R12-07](work-items/r12/R12-07-preview-evolution.md); R13 owns current implementation, and its first
-  dependency-closed publication wave will supply R12-07's evidence
+- Most recently completed child: [R12-07 — Preview evolution](work-items/r12/R12-07-preview-evolution.md)
+- Pending release boundary: none. R12 and R13 are complete; S3 and Backup are shelved.
+- Preview readiness: `GO accepted on 2026-07-22`; public upgrade, mixed-state publisher convergence,
+  feedback triage, and maintainer acceptance are complete
+- Deliberate boundary: this closes 0.20 preview maturity without declaring V1 GA, setting a V1 support
+  date, or widening the generated supported package surface
 
 ## Work items
 
@@ -49,7 +47,7 @@ or completes a work item. The roadmap describes order; it does not report progre
 | R09 | [Compile the Semantic Composition Kernel](work-items/R09-semantic-composition-kernel.md) | T7A | passed | R07; protects R08-01 | Codex · 2026-07-17 | R09-01 through R09-09 passed. One retained module lifecycle, compiled semantic constitution, typed contribution/election mechanics, hard capability overlays, canonical evidence, contract isolation, and legacy-kernel deletion are proved. ARCH-0115 and ARCH-0116 record the result. |
 | R10 | [Graduate the golden sample portfolio](work-items/R10-golden-samples.md) | T7B | passed | R09; R08-04 | Codex · 2026-07-17 | All eleven children pass. Ten public applications build strictly; eight sample suites pass 45 with 2 intentional skips. Canon is automatic, CustomerCanon is graduated, and the portfolio no longer blocks package polish. |
 | R11 | [Graduate the NuGet product surface](work-items/R11-package-product-quality.md) | T7B | passed | R09; R10; guards R08-05 | Architect + Codex · 2026-07-19 | R11-01 through R11-07 pass. All 93 active packages have terminal topology, package-owned presentation, and zero objective findings; the complete public-release ratchet passed 4,648 tests with 30 intentional skips and no failures. |
-| R12 | [Road to the 0.20 Preview](work-items/R12-road-to-020-preview.md) | T7C | in-progress | R08 local evidence; R09; R10; R11 | Maintainer + Codex · 2026-07-22 | R12-01 through R12-06 are complete. R12-07 now has public before/after upgrade, mixed immutable-set publication convergence, and feedback triage evidence; its technical recommendation is GO and awaits explicit maintainer acceptance. |
+| R12 | [Road to the 0.20 Preview](work-items/R12-road-to-020-preview.md) | T7C | passed | R08 local evidence; R09; R10; R11 | Maintainer + Codex · 2026-07-22 | R12-01 through R12-07 pass. The maintainer explicitly accepted the technical GO after public before/after upgrade, mixed immutable-set publication convergence, and feedback triage evidence. |
 | R13 | [Promote the meaningful public surface to 0.20](work-items/R13-terminal-package-maturity.md) | T8 | passed | R11; R12-06; ARCH-0120 | Maintainer + Codex · 2026-07-22 | Entity through external Auth are public, indexed, consumer-green, and baseline-captured. R13-18 keeps unready cross-repository migrations truthful at 0.17 without blocking closure; S3 and Backup are shelved. |
 
 Allowed status values are `pending`, `in-progress`, `blocked`, `passed`, and `stopped`. Only one work
@@ -71,13 +69,14 @@ item should normally be `in-progress`.
 | R09 | passed | All nine children pass. Functional assemblies use one module lifecycle, contracts are isolated without activation metadata, the duplicate bootstrap kernel is deleted, and focused source/package journeys remain meaningful. |
 | R10 | passed | All eleven children pass. Ten public applications, their index/solution membership, current docs, and eight executable sample suites agree. |
 | R11 | passed | R11-01 through R11-07 pass. The 93-package graph, 26 claims, package-owned prose, objective zero-finding quality report, clean packs, focused family evidence, and complete public-release ratchet agree. |
-| R12 | in-progress | Technical evidence is complete: the public app upgraded from exact 0.20.4 packages to current 0.20.* packages with the same result, mixed-state publication converged, and feedback was triaged. Maintainer GO acceptance remains. |
+| R12 | passed | The public app upgraded from exact 0.20.4 packages to current 0.20.* packages with the same result, mixed-state publication converged, feedback was triaged, and the maintainer accepted GO on 2026-07-22. |
 | R13 | passed | Entity, Vector/Search, AI runtime/providers, Local Storage/Media, and external Auth are public, indexed, public-consumer green, and API-baseline complete. R13-18 found no public destination evidence for the accepted Agyo/Zen Garden moves, so six unclaimed owners remain truthfully at 0.17 under ARCH-0089 rather than being deleted or promoted. S3 and Backup are shelved. |
 
 ## Divergence and risk log
 
 | Date | Item | Observation | Disposition |
 |---|---|---|---|
+| 2026-07-22 | R12 preview acceptance | The technical GO recommendation was backed by public upgrade, publication convergence, and bounded feedback evidence; the only remaining gate was explicit maintainer acceptance. | The maintainer accepted GO. R12 and the 0.20 preview maturity cycle pass. This decision does not declare V1 GA, set a V1 support date, or widen the supported package surface. |
 | 2026-07-22 | R13 accepted migration disposition | Agyo's public tip contains substantial RAG but no migrated Agents/Orchestration loop, standalone Eval/Review projects, or public NuGet package IDs. Zen Garden's public tip has not advanced since April and does not prove the complete Models/HuggingFace lifecycle destination. | Apply ARCH-0089's transition gate: keep the six departing Koan owners unclaimed at 0.17; perform no deletion, promotion, forwarding package, or sibling mutation. Move the cross-repository work out of the completed 0.20 promotion epic and resume only from public destination/consumer evidence. |
 | 2026-07-22 | Practical merge and publication flow | Per-package NBGV versioning and main publication had become coupled to a 107-project certification ratchet, a permanent PR-native job, a duplicate surface workflow, and repeated consumer proof. This delayed framework work while proving unrelated providers and confused portfolio certification with package identity. | ARCH-0121 keeps one cheap main-PR coherence job and one test-free main publisher. Affected behavior/native tests run during development; clean consumers apply only to first publication or changed artifact shape; the complete ratchet is an explicit whole-framework milestone. The exact replacement flow passed in 86.6 seconds versus about 16 minutes 22 seconds for the preceding connected gate. |
 | 2026-07-21 | R13 first-slice merge ratchet | The first simplified PR ratchet passed build, docs, product truth, API posture, and direct native proof, but its deterministic test leg exposed three real evidence seams: failed-start cleanup masked corrective exceptions, the shared Mongo Web bridge changed the database without preserving authentication source, and the clean consumer omitted locally newer package dependencies. | Keep the lean path and repair each direct owner. Dispose incomplete hosts without an invalid stop sequence; preserve an authenticated Mongo URL's original auth database; derive and pack the promoted owners' complete public project-reference closure through the existing repository inspector. Focused host/Communication/Data and real Mongo evidence pass; rerun the final PR ratchet. |

--- a/docs/initiatives/koan-v1/work-items/R12-road-to-020-preview.md
+++ b/docs/initiatives/koan-v1/work-items/R12-road-to-020-preview.md
@@ -3,19 +3,19 @@ type: SPEC
 domain: framework
 title: "R12 - Road to the 0.20 Preview"
 audience: [architects, maintainers, developers, ai-agents]
-status: current
-last_updated: 2026-07-21
+status: resolved
+last_updated: 2026-07-22
 framework_version: v0.20.0
 validation:
-  date_last_tested: 2026-07-21
-  status: in-progress
-  scope: epic charter and dependency-ordered preview maturity plan
+  date_last_tested: 2026-07-22
+  status: passed
+  scope: R12-01 through R12-07 passed; maintainer accepted the 0.20 preview GO
 ---
 
 # R12 — Road to the 0.20 preview
 
 - Tranche: `T7C — 0.20 public-preview maturity`
-- Status: `in-progress`
+- Status: `passed — 0.20 preview GO accepted on 2026-07-22`
 - Depends on: passed R09, R10, and R11; completed local R08-01 through R08-05 evidence
 - Supersedes: the unexecuted public-observation and upgrade tail of R08
 - Unlocks: a coherent public 0.20 package line that external developers can install, evaluate, and
@@ -88,12 +88,13 @@ Communication, MCP, security, and optional AI/vector capability.
 | [R12-04](r12/R12-04-coherent-public-narrative.md) | every public-facing surface tells one greenfield, present-tense product story and an anti-drift gate preserves it | passed |
 | [R12-05](r12/R12-05-public-consumer-journey.md) | the public template installs from NuGet, generates both starters, restores cleanly, and proves the SQLite-backed consumer result | passed |
 | [R12-06](r12/R12-06-publish-and-observe-first-wave.md) | one `main`-boundary job publishes and observes the exact supported package set without a second release system | passed |
-| [R12-07](r12/R12-07-preview-evolution.md) | the first new dependency-closed R13 wave upgrades a public-created application, proves mixed-state idempotent publication, establishes the feedback baseline, and produces the final R12 go/no-go record | in-progress |
+| [R12-07](r12/R12-07-preview-evolution.md) | the first new dependency-closed R13 wave upgrades a public-created application, proves mixed-state idempotent publication, establishes the feedback baseline, and produces the final R12 go/no-go record | passed |
 
-R12-01 through R12-06 are complete. R12-07 remains one bounded preview-evolution proof and will close
-through the first newly promoted R13 family slice. [ARCH-0120](../../../decisions/ARCH-0120-terminal-package-maturity.md)
-and [R13](R13-terminal-package-maturity.md) own value-led promotion of the meaningful public provider
-surface, so R12 completion does not wait on unrelated families or cross-repository handoffs.
+R12-01 through R12-07 are complete. The maintainer accepted R12-07's evidence-backed GO on
+2026-07-22. [ARCH-0120](../../../decisions/ARCH-0120-terminal-package-maturity.md) and
+[R13](R13-terminal-package-maturity.md) separately own value-led promotion of the meaningful public
+provider surface; R13 is also complete without treating unrelated cross-repository handoffs as R12
+blockers.
 
 ## Scope
 
@@ -142,6 +143,10 @@ R12 passes only when:
 7. a later preview wave proves upgrade and mixed-state idempotent publication recovery;
 8. external feedback is recorded as bounded evidence, not used to reopen architecture by anecdote;
 9. the maintainer receives a concise go/no-go record for the next maturity band.
+
+**Acceptance result:** PASS on 2026-07-22. The maintainer explicitly accepted GO for the coherent
+0.20 preview maturity contract. This closes R12 without declaring V1 GA, setting a V1 support date,
+or promoting packages outside the generated supported surface.
 
 ## Stop conditions
 

--- a/docs/initiatives/koan-v1/work-items/r12/R12-07-preview-evolution.md
+++ b/docs/initiatives/koan-v1/work-items/r12/R12-07-preview-evolution.md
@@ -3,19 +3,19 @@ type: SPEC
 domain: framework
 title: "R12-07 - Prove Preview Evolution"
 audience: [architects, maintainers, release-engineers, ai-agents]
-status: current
+status: resolved
 last_updated: 2026-07-22
 framework_version: v0.20.0
 validation:
-  date_last_tested: 2026-07-21
-  status: in-progress
-  scope: public upgrade and idempotent mixed-state publication evidence complete; maintainer go/no-go pending
+  date_last_tested: 2026-07-22
+  status: passed
+  scope: public upgrade and idempotent mixed-state publication evidence accepted; maintainer GO recorded
 ---
 
 # R12-07 — Prove preview evolution
 
 - Tranche: `T7C — 0.20 public-preview maturity`
-- Status: `in-progress — evidence complete; maintainer go/no-go pending`
+- Status: `passed — maintainer accepted GO on 2026-07-22`
 - Depends on: completed R12-06 and the first dependency-closed publication wave from
   [R13](../R13-terminal-package-maturity.md)
 - Unlocks: R12 completion independently of R13's remaining provider families
@@ -73,8 +73,10 @@ risk without testing a different mechanism, so it is not part of this card.
 
 **Go/no-go recommendation:** GO. The public 0.20 line upgraded through ordinary NuGet semantics, the
 same business expression remained valid, and the one-job publisher converged a mixed immutable set.
-R13 continues provider-family promotion independently. R12 remains open only for the maintainer's
-explicit acceptance of this recommendation.
+R13 completed its provider-family promotion independently.
+
+**Maintainer decision — 2026-07-22:** GO accepted. This closes R12's 0.20 preview-maturity contract.
+It does not declare V1 GA, set a V1 support date, or widen the generated supported package surface.
 
 ## Acceptance
 
@@ -87,6 +89,9 @@ R12-07 passes only when:
    second recovery system or manufactured failure;
 4. feedback is recorded as evidence and triaged into bounded action or explicit non-claim;
 5. the maintainer accepts the final R12 go/no-go record.
+
+**Acceptance result:** PASS on 2026-07-22. All five conditions are satisfied, including the
+maintainer's explicit GO.
 
 ## Stop conditions
 


### PR DESCRIPTION
## Outcome

Records the maintainer's explicit GO for R12-07 and closes the 0.20 preview maturity cycle.

- marks R12-07 and R12 passed
- marks the initiative ledger complete with no active work item
- preserves S3 and Backup as shelved
- preserves unclaimed migration owners outside the supported 0.20 surface
- explicitly does **not** declare V1 GA, set a V1 support date, or widen the generated supported surface

## Validation

- `scripts/docs-lint.ps1` — 0 errors (1,402 existing warnings)
- `scripts/public-docs-lint.ps1` — passed
- `git diff --cached --check` — passed

Documentation-only acceptance record; no package or version changes.