### PR TITLE
Make Koan's public story delightful

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,8 @@
-# Koan Framework
+# Koan
 
-Koan is an opinionated .NET 10 meta-framework for agentic, data-driven applications. Application code
-states business intent; Koan owns composition, provider negotiation, lifecycle, and explanation.
+## Write with intent. Koan makes it real.
 
-> **Current line:** Koan 0.20 is a preview. Supported capabilities and packages are explicit in the
-> [generated product surface](docs/reference/product-surface.md). Package availability alone is not a
-> support promise.
-
-## Build one useful application
-
-Install the public template and create a persisted web API:
-
-```powershell
-dotnet new install Sylin.Koan.Templates
-dotnet new koan-web -o TodoApi
-cd TodoApi
-dotnet run
-```
-
-Use the URL printed by ASP.NET Core, then create and read a Todo and inspect the resolved application:
-
-```powershell
-Invoke-RestMethod -Method Post -Uri http://localhost:5000/api/todos `
-  -ContentType application/json -Body '{"title":"buy milk"}'
-Invoke-RestMethod http://localhost:5000/api/todos
-Invoke-RestMethod http://localhost:5000/.well-known/Koan/facts
-```
-
-The complete application grammar is small:
-
-```csharp
-var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddKoan();
-var app = builder.Build();
-await app.RunAsync();
-```
+Declare what your application knows. Declare how the world reaches it.
 
 ```csharp
 public sealed class Todo : Entity<Todo>
@@ -47,69 +15,66 @@ public sealed class Todo : Entity<Todo>
 public sealed class TodosController : EntityController<Todo>;
 ```
 
-```csharp
-var todo = await new Todo { Title = "Ship it" }.Save();
-var same = await Todo.Get(todo.Id);
-var open = await Todo.Query(item => !item.Done);
-await todo.Remove();
+**Entity. Controller. Done.**
+
+Run it and `/api/todos` is a persisted, queryable HTTP API.
+
+No `DbContext`. No repository. No schema script. No CRUD service. No endpoint mapping.
+
+## Make one
+
+```powershell
+dotnet new install Sylin.Koan.Templates
+dotnet new koan-web -o TodoApi
+cd TodoApi
+dotnet run -- --urls http://localhost:5000
 ```
 
-There is no application repository, `DbContext`, schema bootstrap, controller CRUD plumbing, or list
-of framework services to register.
+Create a Todo. Read it back. It survives the restart.
 
-## Grow by capability
+```powershell
+Invoke-RestMethod -Method Post -Uri http://localhost:5000/api/todos `
+  -ContentType application/json -Body '{"title":"buy milk"}'
+Invoke-RestMethod http://localhost:5000/api/todos
+```
 
-References make capabilities available. `AddKoan()` compiles their modules once, each capability
-elects an eligible provider, and the resolved application explains itself.
+## Agent, meet Todo.
 
-| Need | Canonical capability |
-|---|---|
-| Persist and query business state | [Data](docs/reference/data/index.md) |
-| Expose Entities through HTTP | [Web](docs/reference/web/index.md) |
-| Authenticate users and isolate tenants | [Identity and isolation](docs/reference/identity/index.md) |
-| Run durable work and communicate Entity intent | [Work and communication](docs/reference/communication/index.md) |
-| Cache state, store files, and serve media | [State and content](docs/reference/state-content/index.md) |
-| Add AI, vector, and search behavior | [Intelligence](docs/reference/ai/index.md) |
-| Expose governed tools and resources to agents | [Agents](docs/reference/agents/index.md) |
-| Reconcile records into canonical Entities | [Canon](docs/reference/canon/index.md) |
-| Test, inspect, and operate the application | [Testing and operations](docs/reference/operations/index.md) |
+Add Koan's MCP package and one declaration:
 
-Adding a capability should add business vocabulary rather than infrastructure ceremony. Provider
-differences are declared and negotiated; unsupported intent rejects with a corrective explanation
-instead of silently degrading.
+```powershell
+dotnet add package Sylin.Koan.Mcp
+```
 
-## Inspect the resolved application
+```diff
++using Koan.Mcp;
++
++[McpEntity(Name = "Todo", Description = "Work the team intends to finish")]
+ public sealed class Todo : Entity<Todo>
+```
 
-The same composition decisions appear through:
+Now an MCP client can discover and work with the same `Todo`, through the same model and access
+rules as the rest of your application.
 
-- startup reporting;
-- `/health/live` and `/health/ready`;
-- `/.well-known/Koan/facts` for operators and reviewers;
-- `koan://facts`, `koan://entities`, and `koan://self` for MCP clients; and
-- `koan.lock.json` for referenced-module drift.
+No second domain model. No mirrored service. No handwritten tool handlers.
 
-These are projections of one runtime model, not competing configuration authorities.
+## Let the idea grow
 
-## Choose Koan when
+Today it is a local SQLite API. Tomorrow it can use Postgres, run durable work, publish events,
+search semantically, serve media, or collaborate with an agent.
 
-Choose Koan when your application is naturally Entity-centric, you value conventions over repeated
-plumbing, and you want data, web, jobs, communication, identity, and agent surfaces to compose through
-one inspectable runtime.
+Add only what the application needs. **The code keeps saying `Todo`.**
 
-Koan 0.20 is not a stable 1.0 compatibility promise. Do not assume an unlisted provider guarantee,
-uniform backend cost or behavior, or production readiness merely because a package exists.
+Underneath, it's still ASP.NET Core. Reach for a normal controller or service whenever you want
+one. Want to look behind the magic? Koan tells you what it chose and why.
 
-## Continue
+## Go further
 
-- [Build the first application](docs/getting-started/quickstart.md)
-- [Adopt Koan in an existing application](docs/getting-started/adopt-existing-app.md)
-- [Evaluate the architecture](docs/architecture/index.md)
-- [Choose a capability pillar](docs/index.md)
-- [Run a graduated sample](samples/README.md)
-- [Evaluate the supported product surface](docs/reference/product-surface.md)
-- [Troubleshoot an application](docs/support/troubleshooting.md)
-- [Orient a coding agent](llms.txt)
+- [Build your first Koan application](docs/getting-started/quickstart.md)
+- [Bring Koan into an existing ASP.NET Core application](docs/getting-started/adopt-existing-app.md)
+- [Run complete applications](samples/README.md)
+- [Build for agents](docs/reference/agents/index.md)
+- [Understand the architecture](docs/architecture/index.md)
+- [See what works today](docs/reference/what-works.md)
 
-Architecture decision records preserve historical decisions. For current application behavior, use
-the capability pages, package documentation, graduated samples, generated product surface, and
-repository-owned tests.
+> Koan 0.20 is a .NET 10 preview.

--- a/docfx.json
+++ b/docfx.json
@@ -50,13 +50,24 @@
           "README.md",
           "CONTRIBUTING.md"
         ]
+      },
+      {
+        "files": [
+          "samples/README.md",
+          "samples/**/README.md"
+        ],
+        "exclude": [
+          "**/bin/**",
+          "**/obj/**"
+        ]
       }
     ],
     "resource": [
       {
         "files": [
           "images/**",
-          "other/website/assets/**"
+          "other/website/assets/**",
+          "llms.txt"
         ]
       }
     ],
@@ -91,9 +102,9 @@
     ],
     "disableGitFeatures": false,
     "globalMetadata": {
-      "_appTitle": "Koan Framework Documentation",
-      "_appName": "Koan Framework",
-      "_appFooter": "Koan Framework - Talk to your code, don't fight it",
+      "_appTitle": "Koan — Write with intent",
+      "_appName": "Koan",
+      "_appFooter": "Write with intent. Koan makes it real.",
       "_enableSearch": true,
       "_enableNewTab": true,
       "_disableContribution": false,
@@ -112,6 +123,7 @@
         "documentation/guides/**": "Developer Guides - Koan Framework",
         "docs/reference/**": "API Reference - Koan Framework",
         "documentation/reference/**": "API Reference - Koan Framework",
+        "samples/**": "Stories you can run - Koan",
         "api/**": "API Documentation - Koan Framework"
       },
       "_tocTitle": {
@@ -121,6 +133,7 @@
         "documentation/guides/**": "Guides",
         "docs/reference/**": "Reference",
         "documentation/reference/**": "Reference",
+        "samples/**": "Stories",
         "api/**": "API"
       }
     }

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,99 +1,115 @@
 ---
 type: ARCHITECTURE
 domain: framework
-title: "Evaluate Koan architecture"
+title: "Small code. Serious architecture."
 audience: [architects, developers, technical-leads, ai-agents]
 status: current
-last_updated: 2026-07-22
+last_updated: 2026-07-23
 framework_version: v0.20.0
 validation:
-  date_last_tested: 2026-07-22
+  date_last_tested: 2026-07-23
   status: reviewed
-  scope: architect decision path, responsibility boundary, reference profiles, and quality attributes
+  scope: architect fit, brownfield adoption, responsibility boundary, and production ownership
 ---
 
-# Evaluate Koan architecture
+# Small code. Serious architecture.
 
-Koan is an application framework, not a deployment platform. It gives Entity-centric .NET
-applications one business-facing grammar for capabilities, compiles referenced modules into one
-runtime composition, elects eligible providers, and explains the result. Your application keeps
-ownership of its domain, infrastructure topology, production guarantees, and deliberate exceptions.
+The two declarations are not demo sleight of hand. They are the architecture:
 
-```mermaid
-flowchart LR
-    A["Application<br/>Entities, policies, workflows"] --> K["AddKoan()<br/>compiled composition"]
-    K --> P["Capability pillars<br/>semantic policy and plans"]
-    P --> D["Provider adapters<br/>mechanics and declared guarantees"]
-    D --> E["Application-owned services<br/>databases, brokers, models, identity"]
-    K --> F["One fact model<br/>startup, health, facts, tests, MCP"]
+```csharp
+public sealed class Todo : Entity<Todo>;
+[Route("api/todos")]
+public sealed class TodosController : EntityController<Todo>;
 ```
 
-References make capabilities available; they do not make external commitments disappear. Explicit
-provider intent either wins or fails with a correction. Koan does not silently substitute a weaker
-durability, consistency, isolation, or delivery guarantee.
+`Todo` says what the application knows. `TodosController` says how the outside world reaches it. With
+the web application bundle and SQLite connector, that is a persisted, queryable HTTP API.
 
-## Is Koan a fit?
+The same Entity stays at the center when the application gains authorization, background work,
+events, caching, semantic search, media, or agent access. The business idea remains visible while
+Koan brings the machinery together around it.
 
-Choose Koan when the application is naturally Entity-centric, conventions are preferable to repeated
-plumbing, and provider decisions must remain inspectable while the application grows across data,
-web, work, identity, content, AI, and agent surfaces.
+**The magic is not that Koan hides everything. It is that Koan asks you to say only what matters—and
+can explain the rest.**
 
-Pause when the design requires a stable 1.0 compatibility contract, general cross-provider
-transactions, transparent failover between unequal providers, framework-owned infrastructure
-provisioning, a general backup/recovery system, or NativeAOT. Koan 0.20 does not promise those things.
+## Why it stays small
 
-## Responsibility boundary
+- **Intent stays in charge.** Application code talks about `Todo`, not database sessions, transport
+  envelopes, or tool schemas.
+- **References bring capabilities.** Add a supported package and Koan discovers what it contributes.
+  `AddKoan()` brings those contributions together once as the application starts.
+- **Conventions have exits.** Use a normal ASP.NET Core controller, service, provider SDK, or
+  deliberate override wherever the default is not the right shape.
+- **The application can explain itself.** Startup reports, health, runtime facts, and the composition
+  lockfile show what became active and why.
 
-| Decision | Koan owns | Application and platform own |
-|---|---|---|
-| Composition | module participation, provider election, corrective failure, runtime facts | referenced capabilities, explicit pins, deliberate overrides |
-| Business behavior | concise Entity and capability grammar | domain invariants, workflows, integration contracts |
-| Infrastructure | connector discovery, configuration binding, selected-provider health | Docker/Aspire/Kubernetes, service lifecycle, credentials, network topology |
-| Reliability | truthful capability and delivery semantics | SLOs, redundancy, failover, idempotency policy, incident response |
-| Security | supported authentication, access, tenancy, and redacted explanation surfaces | HTTPS, secrets, trust boundaries, entitlements, compliance, exposed operations |
-| Recovery | provider-specific behavior only where explicitly claimed | backups, restore testing, retention, RPO/RTO, disaster recovery |
+## Where Koan shines
 
-## Reference profiles
+Koan is a strong fit when:
 
-| Profile | Shape | Architectural boundary |
-|---|---|---|
-| Local-first application | one process with SQLite or another supported local provider | fastest supported start; embedded durability and single-node limits remain explicit |
-| Service with managed dependencies | Koan Web plus supported database, identity, AI, or vector connectors | the platform owns service availability, scaling, credentials, backup, and network policy |
-| Distributed work | Jobs plus a supported persistence and Communication connector | work is at-least-once; handlers are idempotent; acceptance is not completion |
-| Governed agent surface | MCP projection over explicitly exposed and authorized application operations | Entity capability is not automatic tool exposure; transport, identity, and access remain explicit |
+- business state maps naturally to Entities;
+- conventions are more valuable than repeating data, API, job, and integration plumbing;
+- the application should start locally and move to external providers without changing its domain
+  vocabulary;
+- people and agents should work through the same governed application model; and
+- architects need framework choices to remain visible at runtime.
 
-These are evaluation profiles, not generated deployment templates. Keep the same application grammar
-while selecting only providers whose published guarantees satisfy the intended profile.
+Take a different path, or keep Koan at a smaller boundary, when the design depends on:
 
-## At more than one instance
+- a stable 1.0 compatibility contract—Koan 0.20 is still a preview;
+- general transactions across different providers;
+- transparent failover between providers with different guarantees;
+- framework-owned infrastructure provisioning, backup, or disaster recovery; or
+- NativeAOT.
 
-| Concern | What changes |
+Koan will not quietly pretend those guarantees exist.
+
+## It can join an application already in motion
+
+Koan does not need to own the whole system. Add `AddKoan()` to an existing ASP.NET Core host,
+introduce one Entity at a useful boundary, and leave the rest alone.
+
+Existing middleware, controllers, EF Core models, repositories, SDK clients, authentication, and
+deployment topology can remain exactly where they are. Adopt another Koan capability only after the
+first one earns its place.
+
+[See incremental adoption in an existing ASP.NET Core application.](../getting-started/adopt-existing-app.md)
+
+## Who owns what
+
+Koan is an application framework, not a deployment platform.
+
+| Koan makes easier | Your application and platform still own |
 |---|---|
-| Embedded Data and Local Storage | State is node-local. Replicas do not become a shared database or filesystem. |
-| External providers | Replicas can share reach; the selected service still owns consistency, HA, backup, and failover. |
-| Jobs and Communication | At-least-once behavior remains. Prove shared persistence and connector reach, then keep handlers idempotent. |
-| Health and facts | Each instance reports its own resolved composition; the platform owns aggregation and rollout policy. |
+| Discovering referenced capabilities and bringing them together | Choosing which capabilities belong in the application |
+| Selecting an eligible provider and explaining the choice | Provider configuration, deliberate overrides, and acceptable guarantees |
+| Entity persistence, API, access, work, and agent conventions | Domain rules, workflows, and integration contracts |
+| Health, runtime facts, and actionable startup failures | SLOs, scaling, credentials, networks, and incident response |
+| Supported authentication, access, and tenant boundaries | Trust design, entitlements, exposed operations, and compliance |
+| Provider behavior that Koan explicitly documents | Backups, restore testing, retention, RPO/RTO, and disaster recovery |
 
-## Architecture review
+Docker, Aspire, Kubernetes, databases, brokers, model runtimes, and identity providers keep doing
+their jobs. Koan connects application intent to them; it does not become them.
 
-Before approving a design, confirm:
+When several instances run, local SQLite and local files remain local to each instance. External
+providers may give instances shared reach, but those services still own consistency, availability,
+backup, and failover. Background work remains at-least-once, so handlers must be idempotent.
 
-1. every required capability and provider is admitted by the
-   [generated product surface](../reference/product-surface.md);
-2. provider-specific consistency, boundedness, durability, and outage behavior satisfy the use case;
-3. tenant, actor, authorization, and integration trust boundaries are explicit;
-4. external topology, secrets, scaling, backup, recovery, and observability have named owners;
-5. readiness, runtime facts, and the composition lockfile expose the decisions operators must verify;
-6. unsupported guarantees fail or remain visible rather than becoming assumptions.
+## Look behind the magic
 
-## Go deeper
+The small code does not require blind trust. A running Koan application can tell you which modules and
+providers became active, why they were selected, whether their dependencies are ready, and whether
+the referenced composition has drifted.
 
-- [Product constitution](product-constitution.md) — durable product and responsibility rules.
-- [Framework principles](principles.md) — composition kernel, pillars, adapters, and runtime truth.
-- [Entity Semantics Contract](entity-semantics-contract.md) — placement and extension rules.
-- [Capability curriculum](../index.md) — application semantics and provider choices.
-- [Testing and operations](../reference/operations/index.md) — evidence, health, facts, and correction.
-- [External topology](../reference/operations/external-topology.md) — integration with existing
-  deployment platforms.
-- [Incremental adoption](../getting-started/adopt-existing-app.md) — coexistence with an existing
-  ASP.NET Core application.
+That visibility is there for development, tests, architecture review, and operations—not as homework
+before someone writes their first Entity.
+
+## Keep exploring
+
+- [See what Koan can do today](../reference/what-works.md)
+- [Bring Koan into an existing application](../getting-started/adopt-existing-app.md)
+- [Read the design principles](principles.md)
+- [Review how capabilities extend Entities](entity-semantics-contract.md)
+- [Test and inspect an application](../reference/operations/index.md)
+- [Plan external infrastructure](../reference/operations/external-topology.md)
+- [Check exact package and support status](../reference/product-surface.md)

--- a/docs/getting-started/adopt-existing-app.md
+++ b/docs/getting-started/adopt-existing-app.md
@@ -4,7 +4,7 @@ domain: core
 title: "Adopt Koan in an existing application"
 audience: [developers, architects, technical-leads, ai-agents]
 status: current
-last_updated: 2026-07-22
+last_updated: 2026-07-23
 framework_version: v0.20.0
 validation:
   date_last_tested: 2026-07-22
@@ -12,33 +12,33 @@ validation:
   scope: incremental ASP.NET Core adoption, coexistence, inspection, and rollback
 ---
 
-# Adopt Koan in an existing application
+# Bring Koan into the app you already have
 
-Koan does not require an application rewrite. Add one capability at a clear boundary, keep the
-existing host and integrations, and expand only after the result earns its place.
+Keep your application. Pick one place where plumbing is louder than intent. Let Koan own just that
+slice, then decide whether it has earned another.
 
-## Add one persisted model
+## Start with one Entity
 
-In an existing ASP.NET Core application, add the supported SQLite connector:
+Add Koan's supported SQLite provider:
 
 ```powershell
 dotnet add package Sylin.Koan.Data.Connector.Sqlite
 ```
 
-Keep the existing host and add one composition call:
+Keep the host you have and add one Koan line:
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddControllers(); // existing application services remain
+builder.Services.AddControllers(); // your existing services stay
 builder.Services.AddKoan();
 
 var app = builder.Build();
-// Keep the application's existing middleware and endpoint mappings here.
+// Keep your existing middleware and endpoint mappings.
 await app.RunAsync();
 ```
 
-Introduce Koan at one new or deliberately carved-out domain boundary:
+Now declare one new—or deliberately carved-out—piece of the domain:
 
 ```csharp
 public sealed class Todo : Entity<Todo>
@@ -46,7 +46,15 @@ public sealed class Todo : Entity<Todo>
     public string Title { get; set; } = "";
     public bool Done { get; set; }
 }
+```
 
+Koan gives that Entity durable SQLite persistence. How much more it owns is your choice.
+
+## Keep your controller
+
+Use Entity operations inside an ordinary ASP.NET Core controller:
+
+```csharp
 [ApiController, Route("api/todos")]
 public sealed class TodosController : ControllerBase
 {
@@ -55,31 +63,49 @@ public sealed class TodosController : ControllerBase
 }
 ```
 
-Existing controllers, middleware, services, EF Core models, repositories, and provider SDK clients
-continue to work. Use `EntityController<T>` only when its projection is the intended boundary.
+Your routes, actions, filters, and response design remain yours.
 
-## What stays ordinary .NET
+## Or declare the whole API
 
-| Existing concern | Adoption rule |
-|---|---|
-| Hosting and DI | Keep the current host and registrations; call `AddKoan()` once. |
-| Controllers and middleware | Keep them. Add Koan projections only where their conventions are useful. |
-| EF Core or repositories | Leave existing aggregates in place; adopt Entity semantics one boundary at a time. |
-| Authentication | Existing ASP.NET Core authorization remains valid; add Koan Identity only when its capability is needed. |
-| External SDK clients | Keep application-specific integrations; use a Koan connector only for a capability Koan owns. |
-| Docker, Aspire, or Kubernetes | Keep the topology unchanged; connectors consume configuration and report readiness. |
+When Koan's standard Entity API is exactly what you want, the controller becomes the intent:
 
-## Prove the increment
+```powershell
+dotnet add package Sylin.Koan.App
+```
 
-1. Start the application and read Koan's startup composition.
-2. Exercise the new business path while existing paths remain unchanged.
-3. Add an Entity conformance test when the boundary is intended to remain.
-4. Confirm the selected provider and its limits in the
-   [product surface](../reference/product-surface.md).
+```csharp
+[Route("api/todos")]
+public sealed class TodosController : EntityController<Todo>;
+```
 
-If the increment does not help, remove the package reference, the new Entity boundary, and
-`AddKoan()` when no other Koan capability uses it. Data already written to the selected provider is an
-application migration decision; Koan does not silently move or delete it.
+**Entity. Controller. Done—even inside the application you already have.**
 
-Continue with the [capability curriculum](../index.md), or review
-[architecture responsibilities](../architecture/index.md) before adding another capability.
+The App bundle adds Koan's ASP.NET Core integration; the explicit SQLite reference remains the
+provider for this Entity.
+
+## Nothing else has to move
+
+Existing controllers, middleware, services, EF Core models, repositories, authentication, and SDK
+clients continue to work. Your Docker, Aspire, or Kubernetes topology stays where it is. Koan
+connectors consume configuration and report readiness; they do not take over deployment.
+
+Adopt Entity semantics only at boundaries where they make the code clearer. Reach for ordinary .NET
+everywhere else.
+
+## Let the result earn the next step
+
+Run the application and exercise both the new path and an unchanged one. Koan's startup report shows
+what it added; `/.well-known/Koan/facts` shows the same choices in a machine-readable form.
+
+Before expanding the boundary:
+
+1. Add an Entity conformance test if this behavior should remain.
+2. Check the selected provider and its limits in [what works today](../reference/what-works.md).
+3. Add the next capability only when the application asks for it.
+
+If the experiment is not helping, remove the package and the Entity boundary. Remove `AddKoan()` too
+when no other Koan feature uses it. Data already written to SQLite remains an application migration
+decision; Koan will never silently move or delete it.
+
+Ready for another slice? [Choose what to add next](../index.md), or read
+[where Koan fits—and where it stops](../architecture/index.md).

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -4,7 +4,7 @@ domain: core
 title: "Build your first Koan application"
 audience: [developers, ai-agents]
 status: current
-last_updated: 2026-07-22
+last_updated: 2026-07-23
 framework_version: v0.20.0
 validation:
   date_last_tested: 2026-07-21
@@ -14,44 +14,9 @@ validation:
 
 # Build your first Koan application
 
-## Result
+Five minutes. One Entity. One Controller. A real API that keeps its data.
 
-You will create a .NET 10 web application, persist a Todo through SQLite, expose it through HTTP, and
-inspect why Koan selected that runtime shape.
-
-## Create and run
-
-```powershell
-dotnet new install Sylin.Koan.Templates
-dotnet new koan-web -o TodoApi
-cd TodoApi
-dotnet run
-```
-
-Use the URL printed by ASP.NET Core. In another shell:
-
-```powershell
-Invoke-RestMethod -Method Post -Uri http://localhost:5000/api/todos `
-  -ContentType application/json -Body '{"title":"buy milk"}'
-Invoke-RestMethod http://localhost:5000/api/todos
-Invoke-RestMethod http://localhost:5000/.well-known/Koan/facts
-```
-
-The POST and GET prove the application result. The facts response explains the referenced modules,
-selected data provider, configuration provenance, and readiness posture that produced it.
-
-## Read the application
-
-The host is the normal .NET host plus one Koan composition call:
-
-```csharp
-var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddKoan();
-var app = builder.Build();
-await app.RunAsync();
-```
-
-The business model and HTTP surface are:
+This is the application you are about to run:
 
 ```csharp
 public sealed class Todo : Entity<Todo>
@@ -64,43 +29,78 @@ public sealed class Todo : Entity<Todo>
 public sealed class TodosController : EntityController<Todo>;
 ```
 
-Referenced capabilities contribute persistence, schema readiness, controller conventions, startup
-reporting, health, and runtime facts. The application contains no repository, `DbContext`, schema
-script, provider registration, or controller CRUD implementation.
+That is the intent. Koan brings the persisted, queryable HTTP API.
 
-## Guarantee and correction
+## Make it real
 
-The template references the supported SQLite provider and uses compatible `0.20.*` package ranges.
-SQLite provides durable embedded storage for a local or single-node application; it does not promise
-remote-database behavior or multi-node writes.
+You need the .NET 10 SDK.
 
-If a configured provider was not referenced or cannot satisfy the requested capability, Koan rejects
-the intent and names the missing package, configuration, or provider guarantee. It does not silently
-move the Entity to another backend.
+```powershell
+dotnet new install Sylin.Koan.Templates
+dotnet new koan-web -o TodoApi
+cd TodoApi
+dotnet run -- --urls http://localhost:5000
+```
 
-## Inspect before changing configuration
+In another shell, create a Todo and read it back:
 
-1. Read the startup report.
-2. Use `/health/live` for process liveness.
-3. Use `/health/ready` for selected dependency readiness.
-4. Read `/.well-known/Koan/facts` for the redacted composition decisions.
-5. Review `koan.lock.json` when referenced modules change.
+```powershell
+Invoke-RestMethod -Method Post -Uri http://localhost:5000/api/todos `
+  -ContentType application/json -Body '{"title":"buy milk"}'
+Invoke-RestMethod http://localhost:5000/api/todos
+```
 
-## Add the next capability
+Stop the app, start it again, and repeat the GET. Your Todo is still there.
 
-Choose by business need:
+**Entity. Controller. Done.**
 
-- [Data](../reference/data/index.md) for queries, relationships, paging, streaming, and providers.
-- [Web](../reference/web/index.md) for HTTP conventions and projections.
-- [Identity and isolation](../reference/identity/index.md) for authentication, access, and tenancy.
-- [Work and communication](../reference/communication/index.md) for Jobs, Events, and Transport.
-- [State and content](../reference/state-content/index.md) for Cache, Storage, and Media.
-- [Intelligence](../reference/ai/index.md) for AI, vector, and search capabilities.
-- [Agents](../reference/agents/index.md) for governed MCP exposure.
-- [Testing and operations](../reference/operations/index.md) for conformance and diagnostics.
+## Where did the plumbing go?
 
-For a complete repository-owned application, run [FirstUse](../../samples/FirstUse/README.md). Use
-only the [graduated sample portfolio](../../samples/README.md) as current application curriculum.
+The generated host is ordinary ASP.NET Core with one Koan call:
 
-Already have an ASP.NET Core application? [Adopt one capability incrementally](adopt-existing-app.md)
-without replacing its controllers, services, data access, or deployment topology.
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddKoan();
+var app = builder.Build();
+await app.RunAsync();
+```
+
+The template references Koan's SQLite provider. From that reference and your declarations, Koan
+sets up persistence, prepares the schema, maps the controller, and reports whether the app is ready.
+
+There is no repository, `DbContext`, schema script, provider registration, CRUD service, or endpoint
+mapping to maintain.
+
+Want to look behind the magic?
+
+```powershell
+Invoke-RestMethod http://localhost:5000/.well-known/Koan/facts
+```
+
+The response shows what Koan found, what it selected, and why. For quick operational checks, use
+`/health/live` and `/health/ready`.
+
+## Let the idea grow
+
+Keep the Entity. Add only what the application needs:
+
+- [Change or expand its data](../reference/data/index.md).
+- [Give it identity and tenant boundaries](../reference/identity/index.md).
+- [Add jobs, events, or messaging](../reference/work/index.md).
+- [Add AI and semantic search](../reference/ai/index.md).
+- [Let an agent discover and work with it](../reference/agents/index.md).
+
+Or open a complete, runnable story in the [sample portfolio](../../samples/README.md). The
+[FirstUse application](../../samples/FirstUse/README.md) is the smallest complete example.
+
+Already have an ASP.NET Core application? [Bring Koan into one boundary](adopt-existing-app.md)
+without replacing what already works.
+
+## Start small. Know the edges.
+
+Koan 0.20 is a .NET 10 preview. The template uses compatible `0.20.*` packages and durable embedded
+SQLite storage, which is a great fit for local and single-node applications—not a promise of
+remote-database or multi-node-write behavior.
+
+When you choose another provider, Koan will not quietly fall back to a different one. If its package
+or configuration is missing, startup tells you what to add or change.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,71 +4,58 @@ domain: framework
 title: "Koan documentation"
 audience: [developers, operators, architects, ai-agents]
 status: current
-last_updated: 2026-07-22
+last_updated: 2026-07-23
 framework_version: v0.20.0
 validation:
-  date_last_tested: 2026-07-22
-  status: verified
-  scope: greenfield capability curriculum and canonical public navigation
+  date_last_tested: 2026-07-23
+  status: reviewed
+  scope: public documentation home and reader paths
 ---
 
-# Koan documentation
+# Bring an idea
 
-Start with the business capability your application needs. Each pillar gives you the smallest current
-application expression, the guarantee it creates, provider and configuration choices, the corrective
-failure when that guarantee cannot be met, and links to package-specific or operational detail.
+Koan starts with the thing your application is about.
 
-If Koan is new to you, install `Sylin.Koan.Templates` and
-[build the first application](getting-started/quickstart.md). The root [README](../README.md) owns
-Koan's product promise and shortest meaningful result; the generated product surface owns maturity.
+```csharp
+public sealed class Todo : Entity<Todo>
+{
+    public string Title { get; set; } = "";
+}
 
-## Choose your path
+[Route("api/todos")]
+public sealed class TodosController : EntityController<Todo>;
+```
 
-| You want to… | Start here |
-|---|---|
-| Build a new application | [First application](getting-started/quickstart.md) |
-| Add Koan to an existing ASP.NET Core application | [Incremental adoption](getting-started/adopt-existing-app.md) |
-| Evaluate fit, responsibilities, and deployment shapes | [Architecture at a glance](architecture/index.md) |
-| Review security or production behavior | [Identity and isolation](reference/identity/index.md) and [testing and operations](reference/operations/index.md) |
-| Extend a capability or contribute a provider | [Contributing](../CONTRIBUTING.md) and [engineering workbooks](engineering/README.md) |
-| Orient a coding agent | [Agent retrieval map](../llms.txt) |
+That is enough for a persisted, queryable API in the Koan web starter. From there, the same `Todo`
+can gain durable work, events, identity, semantic search, media, or a governed agent surface without
+turning into a different application at every layer.
 
-## Capability pillars
+## Start where you are
 
-| Business need | Pillar | First public concept |
-|---|---|---|
-| Understand composition and provider election | [Foundation and composition](reference/core/index.md) | `AddKoan()` and referenced modules |
-| Persist, query, relate, page, or stream business state | [Data](reference/data/index.md) | `Entity<T>` statics and instance verbs |
-| Expose the same model through HTTP | [Web](reference/web/index.md) | `EntityController<T>` |
-| Authenticate, authorize, and isolate application data | [Identity and isolation](reference/identity/index.md) | provider configuration, `[Access]`, and tenant context |
-| Run durable work and communicate Entity intent | [Work and communication](reference/work/index.md) | `IKoanJob<T>`, `.Events`, and `.Transport` |
-| Cache state, store files, and serve derivatives | [State and content](reference/state-content/index.md) | `[Cacheable]`, storage bindings, and media recipes |
-| Add AI, vector, and search behavior | [Intelligence](reference/ai/index.md) | AI sources, `[Embedding]`, and vector search |
-| Expose governed tools and resources to agents | [Agents](reference/agents/index.md) | `[McpEntity]` and `[McpTool]` |
-| Reconcile records into trusted Entities | [Canon](reference/canon/index.md) | canonical pipelines and contributors |
-| Test, inspect, and operate the application | [Testing and operations](reference/operations/index.md) | conformance, health, facts, and diagnostics |
+- **[Make your first Koan application](getting-started/quickstart.md)** — Go from a template to
+  stored data and a working API.
+- **[Bring Koan into an application you already have](getting-started/adopt-existing-app.md)** — Add
+  one Entity boundary while your controllers, services, EF models, and deployment stay put.
+- **[Run an application with a story](../samples/README.md)** — Tend a garden, organize a photo
+  vault, reconcile customers, or follow the complete first journey.
+- **[Let an agent meet your application](reference/agents/index.md)** — Expose the same model and
+  access rules through MCP—without building a second agent API.
 
-## Product truth
+## Let the idea grow
 
-- [Product and package surface](reference/product-surface.md) is the sole support-maturity authority.
-- [Package quality](reference/package-quality.md) reports structural package facts, not maturity.
-- Package READMEs own provider-specific installation, configuration, and limits.
-- Package technical companions own internals, lifecycle, extension points, and operational detail.
-- [Graduated samples](../samples/README.md) demonstrate complete business journeys without redefining
-  pillar contracts.
+- [Store and query it](reference/data/index.md), then [give it an HTTP surface](reference/web/index.md).
+- [Know who is acting](reference/identity/index.md) and keep tenant boundaries intact.
+- [Run durable work and communicate](reference/work/index.md) without inventing a parallel work model.
+- [Add AI and semantic search](reference/ai/index.md), or [work with files and media](reference/state-content/index.md).
+- [Turn imperfect arrivals into trusted records](reference/canon/index.md).
 
-## Operate and evaluate
+Add what the application asks for. The domain code should remain the easiest part to recognize.
 
-- [Architecture at a glance](architecture/index.md)
-- [Troubleshooting](support/troubleshooting.md)
-- [HTTP API reference](reference/web/http-api.md)
-- [Glossary](reference/glossary.md)
-- [Product constitution](architecture/product-constitution.md)
-- [Entity semantics contract](architecture/entity-semantics-contract.md)
-- [Framework principles](architecture/principles.md)
+## Look behind the magic
 
-## Documentation boundary
+- [Decide whether Koan fits](architecture/index.md).
+- [See what works today](reference/what-works.md).
+- [Troubleshoot a running application](support/troubleshooting.md).
+- [Orient a coding agent](../llms.txt).
 
-Current public guidance is reachable from this curriculum, an owning package, or a graduated sample.
-Initiatives, assessments, proposals, implementation plans, and archives are engineering evidence—not
-alternate application patterns. ADRs are dated decision history and may describe an earlier system.
+> Koan 0.20 is a .NET 10 preview.

--- a/docs/reference/agents/index.md
+++ b/docs/reference/agents/index.md
@@ -4,7 +4,7 @@ domain: mcp
 title: "Agents"
 audience: [developers, operators, architects, ai-agents]
 status: current
-last_updated: 2026-07-22
+last_updated: 2026-07-23
 framework_version: v0.20.0
 validation:
   date_last_tested: 2026-07-22
@@ -12,60 +12,83 @@ validation:
   scope: governed MCP Entity, tool, resource, and transport entry points
 ---
 
-# Agents
+# Agent, meet your app.
 
-Use this pillar when an application must expose governed Entity operations, custom tools, or runtime
-self-description to an MCP client.
+Your `Todo` already persists. It may already have an HTTP API. Add Koan's MCP package and one
+declaration:
 
-## Smallest Entity surface
+```powershell
+dotnet add package Sylin.Koan.Mcp
+```
+
+```diff
++using Koan.Mcp;
++
++[McpEntity(Name = "Todo", Description = "Work the team intends to finish")]
+ public sealed class Todo : Entity<Todo>;
+```
+
+**That's it.**
+
+An MCP client can now discover `Todo`, understand its shape, and use the operations available to
+that caller.
+
+Same Entity. Same data. Same access rules.
+
+No second domain model. No mirrored service. No handwritten CRUD tools. The ordinary `AddKoan()`
+host stays exactly as it is—the package reference brings MCP into the application.
+
+## One idea, every doorway
 
 ```csharp
 [McpEntity(Name = "Todo", Description = "Work the team intends to finish")]
 public sealed class Todo : Entity<Todo>;
+
+[Route("api/todos")]
+public sealed class TodosController : EntityController<Todo>;
 ```
 
-Reference `Sylin.Koan.Mcp` and keep the ordinary `AddKoan()` host. The module contributes discovery,
-tools, resources, and the configured transport. Applications do not call a separate MCP registration
-method or manually map MCP endpoints.
+A Todo created by an agent is immediately visible through the HTTP API. A Todo created through HTTP
+is immediately available to the agent. Both reach the same model and the same application policy.
 
-## Guarantee and correction
+## The magic respects your walls
 
-`[McpEntity]` projects applicable Entity operations through the same model and access policy used by
-other surfaces. `[McpTool]` owns custom operations that are not Entity CRUD. Field exposure attributes
-shape input/output schemas without changing persistence.
+An agent sees only what you deliberately expose and what its identity may use.
 
-An operation that fails access, input binding, capability, or transport requirements returns the
-specific protocol/application correction. A referenced MCP package does not make every Entity or
-method agent-visible.
-
-## Declare what the client may see
-
-| Declaration | Result |
+| Write this | The agent gets |
 |---|---|
-| `[McpEntity]` | Projects applicable Entity operations and schema |
-| `[Access(...)]` plus `EntityAccess<T>` | Applies the same gate and row constraint as other Entity projections |
-| `[McpTool]` | Adds one custom operation that is not Entity CRUD |
-| `[McpDescription]` / `[McpIgnore]` | Describes or omits fields in the agent schema |
-| `[McpReadOnly]`, `[McpDestructive]`, `[McpIdempotent]` | Adds behavioral hints to a custom tool |
-| `IMcpResourceProvider` | Adds an inspectable `koan://...` resource |
+| `[McpEntity]` | The applicable Entity operations and schema |
+| `[Access(...)]` and `EntityAccess<T>` | The same gate and row boundaries used by other Entity surfaces |
+| `[McpTool]` | One business action beyond Entity operations |
+| `[McpDescription]` and `[McpIgnore]` | A clearer schema with only the fields you intend |
+| `[McpReadOnly]`, `[McpDestructive]`, and `[McpIdempotent]` | Useful behavioral hints on a custom tool |
+| `IMcpResourceProvider` | An inspectable `koan://...` resource |
 
-Advertisement and enforcement share the caller's grant. A walled Entity, verb, edge, or field is
-absent rather than replaced with an existence-leaking placeholder. Tool-call failures retain the
-same access, input, capability, and correlation meaning as the application operation beneath them.
+A forbidden Entity, operation, relationship, or field simply does not appear for that caller. Failed
+calls preserve the application's access, input, capability, and correlation details so the client
+can respond intelligently.
 
-## Choose a transport deliberately
+Referencing MCP does **not** expose every Entity or method, invent an authorization policy, or turn
+behavioral hints into enforcement. Your application still decides who may do what.
 
-- STDIO is the local process default.
-- Streamable HTTP is the current network transport.
-- Network exposure requires the application's authentication, authorization, origin, proxy, and TLS
-  decisions; MCP does not create those policies.
+## Start close. Open the network deliberately.
 
-Inspect `koan://facts`, `koan://entities`, and `koan://self` before guessing which resources and tools
-were compiled.
+STDIO is the default: ideal when a local client owns the Koan process.
 
-## Deeper contracts
+Streamable HTTP is available when an MCP client must reach the application over a network. Enable it
+deliberately, then apply the same authentication, authorization, origin, proxy, and TLS decisions you
+would to any other application endpoint. MCP does not create those policies for you.
 
-- [Agent-native task guide](../../guides/mcp-agent-native-howto.md)
-- [MCP HTTP transport](../../guides/mcp-http-sse-howto.md)
-- [MCP package](../../../src/Koan.Mcp/README.md)
-- [Product and package surface](../product-surface.md)
+## Let the application introduce itself
+
+An agent does not have to guess what it connected to:
+
+- `koan://self` introduces the application.
+- `koan://entities` describes the Entity operations available to this caller.
+- `koan://facts` explains what Koan composed, with sensitive values redacted.
+
+## Make the next move
+
+- [Build an agent-native workflow](../../guides/mcp-agent-native-howto.md)
+- [Reach Koan over MCP HTTP](../../guides/mcp-http-sse-howto.md)
+- [See what works in Koan 0.20](../what-works.md)

--- a/docs/reference/what-works.md
+++ b/docs/reference/what-works.md
@@ -1,0 +1,111 @@
+---
+type: REFERENCE
+domain: framework
+title: "What you can make with Koan today"
+audience: [developers, architects, technical-leads, ai-agents]
+status: current
+last_updated: 2026-07-23
+framework_version: v0.20.0
+validation:
+  date_last_tested: 2026-07-23
+  status: reviewed
+  scope: human-readable outcome map over the generated v0.20 product surface
+---
+
+# One Entity. A lot of places to go.
+
+Start with the idea:
+
+```csharp
+public sealed class Todo : Entity<Todo>;
+[Route("api/todos")]
+public sealed class TodosController : EntityController<Todo>;
+```
+
+With the web application bundle and SQLite connector, those declarations become a durable,
+queryable HTTP API. From there, add only what the application asks for. The code can keep talking
+about `Todo`.
+
+## Make it persistent and reachable
+
+Entities can save, query, page, stream where the provider supports it, and travel through
+conventional HTTP APIs. Start with durable local SQLite, or bring PostgreSQL, SQL Server,
+CockroachDB, MongoDB, Couchbase, or Redis when the application needs their reach.
+
+[Explore data](data/index.md) · [Explore HTTP APIs](web/index.md)
+
+## Give it work to do
+
+Run Entity-owned jobs with progress, retries, cancellation, and schedules. Raise a business event or
+send an Entity snapshot without beginning with a queue topology. Keep it in-process, or use RabbitMQ
+when the message must cross a process boundary.
+
+[Explore jobs, events, and communication](work/index.md)
+
+## Let it recognize people—and boundaries
+
+Add sign-in, authorization, durable identities, OAuth token issuance, tenant isolation, and
+classified-field encryption. Google, Microsoft, and Discord providers are available, along with a
+deterministic local identity provider for development and tests.
+
+The same access declaration can govern what HTTP callers and agents are allowed to see and do.
+
+[Explore identity and isolation](identity/index.md)
+
+## Teach it to understand meaning
+
+Chat, stream responses, or create embeddings through one application-facing client when an active
+provider supports the operation. Koan 0.20 works locally with Ollama, LM Studio, and in-process ONNX
+within their model and runtime limits.
+
+Use Koan's Entity vector API for semantic search. Begin in memory or with embedded `sqlite-vec`;
+move to Qdrant, Milvus, Weaviate, Elasticsearch, or OpenSearch when external reach makes sense.
+
+[Explore AI and vector search](ai/index.md)
+
+## Invite an agent in
+
+```csharp
+[McpEntity(Name = "Todo", Description = "Work the team intends to finish")]
+public sealed class Todo : Entity<Todo>;
+```
+
+Now an MCP client can discover and work with the same Entity. No mirrored agent model. No handwritten
+CRUD tool handlers. Koan advertises only the operations and fields that caller is allowed to use.
+
+[Explore agents and MCP](agents/index.md)
+
+## Give it files, images, and memory
+
+Bind Entities to local file storage, transform and serve images through named media recipes, or add
+typed caching without changing ordinary Entity operations. Cache can stay local, survive restart
+through the supported SQLite adapter, or move to another engine after checking its current support
+status.
+
+[Explore storage, media, and cache](state-content/index.md)
+
+## Turn arrivals into trusted records
+
+Canon can normalize and reconcile imperfect customer, device, account, or other arrivals into a
+trusted Entity. Your code names the identity and business rules; Koan runs the deterministic
+pipeline, persistence, lineage, audit, and optional HTTP projection.
+
+[Explore Canon](canon/index.md)
+
+## See what the application became
+
+Health endpoints, runtime facts, OpenTelemetry, and reusable Entity conformance tests make Koan's
+choices visible. You can keep the short application code without treating the framework as a black
+box.
+
+[Explore testing and operations](operations/index.md)
+
+## The honest edges
+
+Koan 0.20 is a .NET 10 preview. It does not provision production infrastructure, promise general
+cross-provider transactions or transparent failover, manage backups and disaster recovery, or
+support NativeAOT. Provider-specific consistency, query, durability, and deployment limits still
+matter.
+
+This page is the human map. For exact package ownership, maturity, evidence, and support status, use
+the generated [Koan product surface](product-surface.md).

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -3,109 +3,109 @@
 - name: Start
   href: getting-started/quickstart.md
   items:
-    - name: Build a new application
+    - name: Make your first application
       href: getting-started/quickstart.md
-    - name: Adopt in an existing application
+    - name: Bring Koan into an existing app
       href: getting-started/adopt-existing-app.md
-- name: Capability pillars
-  href: reference/core/index.md
+- name: Build
+  href: reference/what-works.md
   items:
-    - name: Foundation and composition
+    - name: How Koan starts
       href: reference/core/index.md
     - name: Data
       href: reference/data/index.md
-    - name: Web
+    - name: HTTP APIs
       href: reference/web/index.md
-    - name: Identity and isolation
+    - name: Identity and tenancy
       href: reference/identity/index.md
-    - name: Work and communication
+    - name: Jobs, events, and messages
       href: reference/work/index.md
       items:
-        - name: Jobs
+        - name: Background jobs
           href: reference/jobs/index.md
-        - name: Entity events and transport
+        - name: Events and transport
           href: reference/communication/index.md
-    - name: State and content
+    - name: Cache, files, and media
       href: reference/state-content/index.md
       items:
         - name: Cache
           href: reference/data/cache.md
-        - name: Storage
+        - name: Files and storage
           href: reference/storage/index.md
         - name: Media
           href: reference/media/index.md
-    - name: Intelligence
+    - name: AI and semantic search
       href: reference/ai/index.md
       items:
         - name: Vector search
           href: reference/ai/vector.md
-    - name: Agents
+    - name: Agents and MCP
       href: reference/agents/index.md
-    - name: Canon
+    - name: Trusted records with Canon
       href: reference/canon/index.md
-    - name: Testing and operations
+    - name: Test and understand the app
       href: reference/operations/index.md
       items:
         - name: OpenTelemetry
           href: reference/operations/observability.md
-        - name: External topology
+        - name: External services
           href: reference/operations/external-topology.md
-        - name: NativeAOT boundary
+        - name: NativeAOT
           href: reference/operations/native-aot.md
-- name: Task guides
+- name: How to…
   href: guides/README.md
   items:
-    - name: Entity access and streaming
+    - name: Read and stream Entities
       href: guides/data/entity-access-and-streaming.md
-    - name: Configure authentication
+    - name: Add sign-in
       href: guides/authentication-setup.md
     - name: Issue OAuth tokens
       href: guides/oauth-server-howto.md
-    - name: Apply tenant isolation
+    - name: Isolate tenants
       href: guides/tenancy-howto.md
-    - name: Build background work
+    - name: Run background work
       href: guides/jobs-howto.md
-    - name: Canon capabilities
+    - name: Build trusted records with Canon
       href: guides/canon-capabilities-howto.md
-    - name: Agent-native MCP
+    - name: Let an agent use the app
       href: guides/mcp-agent-native-howto.md
-    - name: MCP over HTTP
+    - name: Reach MCP over HTTP
       href: guides/mcp-http-sse-howto.md
-    - name: Testing an application
+    - name: Test an application
       href: guides/testing-your-app.md
-    - name: Composition lockfile
+    - name: Review what changed
       href: guides/composition-lockfile.md
-- name: Product reference
-  href: reference/product-surface.md
+- name: Reference
+  href: reference/what-works.md
   items:
-    - name: Supported capabilities and packages
+    - name: What works today
+      href: reference/what-works.md
+    - name: Exact package and support status
       href: reference/product-surface.md
     - name: Package quality
       href: reference/package-quality.md
     - name: HTTP API
       href: reference/web/http-api.md
-    - name: Generated .NET API
+    - name: .NET API
       href: api/index.md
-    - name: PATCH normalization
+    - name: PATCH behavior
       href: api/patch-normalization.md
     - name: Glossary
       href: reference/glossary.md
-- name: Samples
+- name: Stories you can run
   href: ../samples/README.md
-- name: Troubleshooting
+- name: Help when something breaks
   href: support/troubleshooting.md
 - name: Architecture
   href: architecture/index.md
   items:
-    - name: Architecture at a glance
+    - name: The big picture
       href: architecture/index.md
-    - name: Product constitution
+    - name: The product promises
       href: architecture/product-constitution.md
-    - name: Entity semantics contract
+    - name: How Entities grow
       href: architecture/entity-semantics-contract.md
-    - name: Framework principles
+    - name: Design principles
       href: architecture/principles.md
-- name: Decision history
-  href: decisions/index.md
 - name: Contributing
   href: ../CONTRIBUTING.md

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,61 +1,56 @@
-# Koan samples
+# Pick an idea. Make it run.
 
-Samples are Koan's public curriculum. Names describe the business result; numbers appear only where
-order has meaning inside a cumulative journey.
+Choose the result that sounds fun. Every sample starts as an ordinary .NET application, runs locally,
+and keeps the interesting code about the thing being built.
 
-These applications teach the Koan 0.20 preview. A sample proves behavior, not package maturity; check
-the [generated product surface](../docs/reference/product-surface.md) before treating a capability as
-supported.
+## Feel the magic
 
-On Windows, every listed sample also starts through the `start.bat` in its own root. The launcher uses
-the same standard `dotnet run` path, works from any caller directory, and forwards optional application
-arguments. The tables retain the portable cross-platform command as the execution contract.
+### Entity. Controller. Agent.
 
-## Start here
+[FirstUse](FirstUse/README.md) turns one `Approval` model—with a one-line controller and one agent
+declaration—into persisted data, an HTTP API, and a governed tool. Start here for the smallest
+complete expression of Koan.
 
-| Sample | Meaningful result | Start |
-|---|---|---|
-| [FirstUse](FirstUse/README.md) | Persist and approve one request; inspect the resulting API, facts, and governed agent tool | `dotnet run --project samples/FirstUse` |
-| [GoldenJourney](GoldenJourney/README.md) | Grow that same application through a rule, durable job, and agent recommendation | `dotnet run --project samples/GoldenJourney` |
+```powershell
+dotnet run --project samples/FirstUse
+```
 
-## Fundamentals
+### Let a simple idea grow
 
-Use these when you want one concern in isolation.
+[GoldenJourney](GoldenJourney/README.md) begins with a review request, then adds a business rule,
+durable background work, and a bounded agent recommendation. The domain stays recognizable at every
+step.
 
-| Sample | Meaningful result | Concepts | Start |
-|---|---|---|---|
-| [LocalChecklist](fundamentals/LocalChecklist/README.md) | Save a checklist, complete one item, and reload open work | console host, Entity statics, JSON | `dotnet run --project samples/fundamentals/LocalChecklist` |
-| [TaskGraph](fundamentals/TaskGraph/README.md) | Resolve one task graph over scalar, set, and stream cardinalities | EntityController, Parent, Relatives, Cache | `dotnet run --project samples/fundamentals/TaskGraph` |
+```powershell
+dotnet run --project samples/GoldenJourney
+```
 
-## Capability journeys
+## Choose your story
 
-[GardenCoop](journeys/GardenCoop/README.md) is one application that grows in meaningful small steps:
+| I want to… | Run this |
+|---|---|
+| Turn dry garden readings into watering reminders | [Garden Journal](journeys/GardenCoop/01-GardenJournal/README.md) |
+| Search local produce with ordinary words—without Docker, an API key, or a vector server | [GardenCoop: Local Discovery](journeys/GardenCoop/02-LocalDiscovery/README.md) |
+| Upload a photo and watch a durable workflow organize it into a private gallery | [SnapVault](applications/SnapVault/README.md) |
+| Turn messy customer arrivals into one trusted customer—or reject them with reasons | [CustomerCanon](applications/CustomerCanon/README.md) |
+| Approve articles and publish them to another named data source | [DevPortal](applications/DevPortal/README.md) |
+| Run a batch, verify every order, clean it up, and keep an honest receipt | [OrderIntake](applications/OrderIntake/README.md) |
 
-1. [Garden Journal](journeys/GardenCoop/01-GardenJournal/README.md) turns dry readings into watering reminders.
-2. [Local Discovery](journeys/GardenCoop/02-LocalDiscovery/README.md) keeps that complete application and adds local semantic produce search.
+[Explore the complete GardenCoop journey](journeys/GardenCoop/README.md) to watch one useful
+application learn something new without losing what already worked.
 
-Each chapter is independently runnable. Every later chapter must preserve the earlier business result,
-then add one visible capability.
+## Take one small bite
 
-## Complete applications
+- [LocalChecklist](fundamentals/LocalChecklist/README.md) saves a checklist, completes an item, and
+  reloads the work in a tiny console application.
+- [TaskGraph](fundamentals/TaskGraph/README.md) makes relationships readable across one Entity, a
+  set, and a stream.
 
-| Sample | Meaningful result | Concepts | Start |
-|---|---|---|---|
-| [DevPortal](applications/DevPortal/README.md) | Approve local articles, publish them through named provider channels, and render entity-backed share cards | named sources, Entity transfer, OpenGraph | `dotnet run --project samples/applications/DevPortal` |
-| [OrderIntake](applications/OrderIntake/README.md) | Run bounded order intake through one named source and keep a verified durable receipt | named sources, Entity batch work, Jobs, readiness | `dotnet run --project samples/applications/OrderIntake` |
-| [SnapVault](applications/SnapVault/README.md) | Upload a photo into a local studio, durably organize and serve it, then share its event without exposing the vault | Entity media, Jobs, tenancy, access, optional AI/vector | `dotnet run --project samples/applications/SnapVault` |
-| [CustomerCanon](applications/CustomerCanon/README.md) | Turn messy customer arrivals into one durable trusted customer, or reject them with reasons | CanonEntity, discovered contributors, generated Canon API, JSON | `dotnet run --project samples/applications/CustomerCanon` |
+Run any sample from the repository root with the command on its page. On Windows, its `start.bat`
+does the same thing from any directory and forwards any application arguments.
 
-Other application directories are active graduation work, not current curriculum. Presence in the tree
-is not a support claim.
+These applications target the Koan 0.20 preview. See [what works today](../docs/reference/what-works.md)
+when deciding what to add to your own application.
 
-The recommendation experience graduated into the standalone
-[Usagi Picks](https://github.com/lbotinelly/usagipicks) product repository. It remains useful Koan application
-evidence, but is no longer bundled sample source or part of this solution.
-
-## Graduation contract
-
-A public sample must have one business sentence, a standard .NET command to a meaningful result, focused
-executable evidence, and documentation that agrees with its source, provider requirements, facts, and
-deployment shape. Business intent must dominate the application code; mechanics belong at framework
-chokepoints. Private dogfood identities and unsupported performance or deployment claims do not belong here.
+Want to see Koan inside a standalone product? Explore
+[Usagi Picks](https://github.com/lbotinelly/usagipicks), an agent-guided recommendation experience.

--- a/scripts/public-docs-lint.ps1
+++ b/scripts/public-docs-lint.ps1
@@ -17,7 +17,8 @@ if (-not (Test-Path -LiteralPath $tocPath)) {
     throw 'docs/toc.yml is missing.'
 }
 
-$trackedPaths = @(git -C $root ls-files --) | ForEach-Object { $_.Replace('\', '/') }
+$trackedPaths = @(git -C $root ls-files --cached --others --exclude-standard --) |
+    ForEach-Object { $_.Replace('\', '/') }
 if ($LASTEXITCODE -ne 0) {
     throw 'Unable to enumerate repository-tracked paths.'
 }
@@ -421,21 +422,53 @@ foreach ($entry in $packageCompanionFiles) {
     }
 }
 
+# Protect the experience at the public front door. Exact package maturity remains the generated
+# ledger's job; these pages must preserve the short intent -> application -> growth journey.
 $frontDoorRequirements = [ordered]@{
-    'README.md' = @('0.20', 'Sylin.Koan.Templates', 'AddKoan()', 'Entity<', 'product surface')
-    'docs/index.md' = @('0.20', 'Sylin.Koan.Templates', 'AddKoan()', 'Entity<', 'product surface')
+    'README.md' = @('Write with intent. Koan makes it real.', 'Entity. Controller. Done.', 'Sylin.Koan.Templates', 'McpEntity', '0.20')
+    'docs/index.md' = @('Bring an idea', 'Entity<', 'what-works.md', 'agents/index.md', '0.20')
+    'docs/getting-started/quickstart.md' = @('Make it real', 'Sylin.Koan.Templates', 'Entity. Controller. Done.', 'AddKoan()')
+    'docs/getting-started/adopt-existing-app.md' = @('Bring Koan into the app you already have', 'one Koan line', 'EntityController<Todo>', 'what-works.md')
+    'samples/README.md' = @('Pick an idea. Make it run.', 'FirstUse', 'GoldenJourney', 'SnapVault', '0.20')
+    'docs/reference/agents/index.md' = @('Agent, meet your app.', 'Sylin.Koan.Mcp', 'McpEntity', 'Same Entity. Same data. Same access rules.')
+    'docs/architecture/index.md' = @('Small code. Serious architecture.', 'Where Koan shines', 'existing ASP.NET Core', 'what-works.md')
+    'docs/reference/what-works.md' = @('One Entity. A lot of places to go.', 'McpEntity', 'product-surface.md', 'Koan 0.20')
     'llms.txt' = @('0.20', 'Sylin.Koan.Templates', 'AddKoan()', 'Entity<', 'product surface')
     'CLAUDE.md' = @('0.20', 'AddKoan()', 'Entity<', 'product-surface.md')
     '.github/copilot-instructions.md' = @('0.20', 'AddKoan()', 'Entity<', 'product-surface.md')
     'templates/README.md' = @('0.20', 'dotnet new install Sylin.Koan.Templates', 'AddKoan()', 'Entity<')
-    'samples/README.md' = @('0.20', 'FirstUse', 'GoldenJourney', 'product surface')
     'docs/reference/product-surface.md' = @('Maturity vocabulary', 'supported-foundation', 'supported-extension', 'verified', 'demonstrated', 'experimental', 'specified', 'unassessed', 'deprecated', 'retired')
 }
 foreach ($path in $frontDoorRequirements.Keys) {
     $content = Get-Content -Raw -LiteralPath (Join-Path $root $path)
     foreach ($phrase in $frontDoorRequirements[$path]) {
         if (-not $content.Contains($phrase, [StringComparison]::OrdinalIgnoreCase)) {
-            $issues.Add("$path is missing canonical front-door phrase '$phrase'.")
+            $issues.Add("$path is missing public-experience anchor '$phrase'.")
+        }
+    }
+}
+
+$delightFrontDoors = @(
+    'README.md',
+    'docs/index.md',
+    'docs/getting-started/quickstart.md',
+    'docs/getting-started/adopt-existing-app.md',
+    'samples/README.md',
+    'docs/reference/agents/index.md',
+    'docs/architecture/index.md',
+    'docs/reference/what-works.md'
+)
+$retiredFrontDoorHeadings = @(
+    '## Guarantee and correction',
+    '## Product truth',
+    '## Graduation contract',
+    '## Prove the increment'
+)
+foreach ($path in $delightFrontDoors) {
+    $content = Get-Content -Raw -LiteralPath (Join-Path $root $path)
+    foreach ($heading in $retiredFrontDoorHeadings) {
+        if ($content.Contains($heading, [StringComparison]::OrdinalIgnoreCase)) {
+            $issues.Add("$path restores retired front-door heading '$heading'; lead with the reader's result.")
         }
     }
 }


### PR DESCRIPTION
## What changed

- opens with **“Write with intent. Koan makes it real.”** and shows the magical path directly: declare an entity, declare a controller, get a persisted API
- rewrites every one-click public destination around outcomes, momentum, and progressive disclosure for developers and architects
- adds a concise “What works” capability page, makes samples and agent workflows inviting, and aligns the DocFX navigation and site identity
- strengthens the public-docs truth gate so new pages participate and bureaucratic front-door language cannot quietly return

## Why

Koan’s public documentation accurately described the framework, but it made readers work through governance language before they could feel the product. This pass makes the first minute match the framework itself: intent first, working software immediately, serious architecture when you need it.

## Developer impact

A new reader can understand Koan’s core promise, see the entity-to-API flow, choose a next step, and reach the right depth without knowing the repository’s internal vocabulary.

## Validation

- `scripts/public-docs-lint.ps1` — passed (690 current assets, 51 navigation targets, 11 graduated sample roots)
- front-door local-link check — all links resolved across 8 pages
- `docfx build docfx.json --logLevel Warning` — succeeded with 0 errors (legacy deep-doc warnings remain)
- `git diff --check` and staged diff check — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reworked the documentation homepage, navigation, quickstart, and adoption guides into shorter, example-driven onboarding paths.
  - Added guidance for incrementally introducing Koan to existing ASP.NET Core applications.
  - Added a new reference page describing supported capabilities and product boundaries.
  - Refreshed agent integration guidance, including MCP setup, visibility, and transport options.
  - Reorganized sample documentation and added sample pages to the documentation site.
  - Updated site branding, navigation labels, version information, and validation metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->