### PR TITLE
Complete dogfood runtime closures

### DIFF
--- a/docs/decisions/ARCH-0122-dogfood-runtime-and-test-seams.md
+++ b/docs/decisions/ARCH-0122-dogfood-runtime-and-test-seams.md
@@ -32,17 +32,21 @@ capability guides rather than becoming another framework curriculum.
 sources at runtime, and drive Jobs deterministically in tests without copying framework internals.
 An engineer or coding agent can discover those paths quickly for greenfield or brownfield work.
 
-**Public expression:** An unnamed `SseEnvelope` remains unnamed. AI exposes `IAiSourceControl` with
-inspect, apply, enable, disable, and remove operations while ordinary routing remains automatic.
+**Public expression:** An unnamed `SseEnvelope` remains unnamed, and an empty envelope carrying
+comment, retry, or id fields is an exact control frame. AI exposes `IAiSourceControl` with inspect,
+apply, enable, disable, and remove operations while ordinary routing remains automatic. Inspection
+reports provider version, installed models, and resident models without exposing a provider client.
 `JobsTestDriver.From(services)` drives the existing Jobs engine after the host opts out of background
 execution. The agent workflow uses the normal package, configuration, Entity, context, and runtime
 surfaces documented by each capability pillar.
 
-**Guarantee/correction:** SSE control frames are not converted to named events and stronger cache
-directives survive. Disabled or removed AI sources leave routing immediately, replacement invalidates
-old health work, and endpoint inspection uses the selected provider's protocol. Jobs tests execute
-the production orchestrator deterministically. Unsupported inspection and incompatible Jobs test
-configuration fail with the exact safe correction.
+**Guarantee/correction:** SSE control frames contain no synthetic event or data field, null data
+still rejects, and stronger cache directives survive. Disabled or removed AI sources leave routing
+immediately, replacement invalidates old health work, and endpoint inspection uses the selected
+provider's protocol. Inspection distinguishes an unreachable endpoint, an available empty installed
+model catalog, and unavailable residency information. Jobs tests execute the production orchestrator
+deterministically. Unsupported inspection and incompatible Jobs test configuration fail with the
+exact safe correction.
 
 **Complete intent surface:** Reference the relevant package and use the API above. Deterministic Jobs
 tests additionally set `JobsOptions.EnableWorker` to `false` and retain normal, non-inline execution.
@@ -72,6 +76,10 @@ An absent event name is meaningful. Fallback event names apply only when the cal
 for that projection. Framework headers use set-if-absent or token composition: they never weaken a
 stronger application or middleware cache directive.
 
+An envelope with empty data and at least one comment, retry, or id field is a protocol control frame.
+The formatter writes only those control fields and the terminating blank line. An empty envelope
+without control fields remains an empty data event, and null data remains invalid.
+
 ### AI source lifecycle
 
 The runtime registry owns a monotonically increasing revision for each applied source. Routing sees
@@ -81,6 +89,22 @@ current, so a late probe cannot resurrect removed, disabled, or replaced state.
 Provider adapters own endpoint inspection because only they know the correct endpoint, request, and
 response grammar. Source control coordinates inspection and lifecycle; it does not reimplement
 provider protocols.
+
+The provider-neutral inspection result carries optional provider version, installed models, and
+resident models. Availability flags distinguish a successful empty collection from a provider facet
+that could not be inspected. Overall availability means the endpoint answered at least one
+provider-owned inspection request; partial failures remain visible in `Detail`.
+
+Ollama owns `/api/version`, `/api/tags`, and `/api/ps`. The application neither calls nor parses those
+endpoints. Other providers populate only the facets their protocol can truthfully inspect.
+
+### Route-hint naming clarification
+
+`WithRouteAdapter` currently carries a source or member hint; the router resolves the actual provider
+adapter from that source. This decision does not add a source-named alias because two names for one
+route field would make the public path less clear. A later semantic rename must change
+`AiRouteHints.AdapterId` and its fluent method together, with one compatibility decision, rather than
+layering another permanent synonym into this closure.
 
 ### Deterministic Jobs testing
 
@@ -119,6 +143,11 @@ retrieval evaluation. They do not encode a private application, infrastructure t
 ## Evidence boundary
 
 Each slice owns focused behavioral tests. The new Jobs package is checked for an xUnit-free dependency
-graph. Agent fixtures receive static structure/link validation; independent cold-agent runs are
-requested only when the workflow itself changes materially. Repository-wide certification remains
-outside this decision under ARCH-0121.
+graph. Agent fixtures receive static structure/link validation; when the workflow itself changes
+materially, each of the three anonymous prompts runs once with a cold agent and retains its raw output
+and signal score. Successful prompts are not repeated and no model matrix is required. Repository-wide
+certification remains outside this decision under ARCH-0121.
+
+The material workflow change accepted by this decision has retained cold-agent evidence at
+`tests/Fixtures/AgentApplicationEngineering/evidence/2026-07-23`: all three anonymous prompts passed
+their declared signals on the first run.

--- a/src/Connectors/AI/LMStudio/LMStudioAdapter.cs
+++ b/src/Connectors/AI/LMStudio/LMStudioAdapter.cs
@@ -227,6 +227,7 @@ internal sealed class LMStudioAdapter :
                 Endpoint = candidate.Endpoint,
                 Available = true,
                 Models = models.Select(model => model.Name).Where(name => name.Length > 0).ToArray(),
+                ModelsAvailable = true,
                 Capabilities = new HashSet<string>(
                     ((IAiAdapter)this).Capabilities,
                     StringComparer.OrdinalIgnoreCase)
@@ -730,4 +731,3 @@ internal sealed class LMStudioAdapter :
         public string? owned_by { get; set; }
     }
 }
-

--- a/src/Connectors/AI/Ollama/Infrastructure/Constants.cs
+++ b/src/Connectors/AI/Ollama/Infrastructure/Constants.cs
@@ -12,7 +12,9 @@ internal static class Constants
     public static class Discovery
     {
         public const int DefaultPort = 11434;
+        public const string VersionPath = "/api/version";
         public const string ModelsPath = "/api/tags";
+        public const string ResidentModelsPath = "/api/ps";
         public const string HostDocker = "host.docker.internal";
         public const string Localhost = "localhost";
         public const string WellKnownServiceName = "ollama";

--- a/src/Connectors/AI/Ollama/OllamaAdapter.cs
+++ b/src/Connectors/AI/Ollama/OllamaAdapter.cs
@@ -241,35 +241,48 @@ internal sealed class OllamaAdapter : IChatAdapter, IEmbedAdapter, IAiSourceInsp
         AiSourceCandidate candidate,
         CancellationToken ct = default)
     {
-        try
+        using var lease = await AcquireConcurrencySlot(ct).ConfigureAwait(false);
+        var endpoint = GetHttpClientForRequest(candidate.Endpoint);
+
+        var version = await InspectEndpoint<OllamaVersionResponse>(
+            endpoint,
+            Infrastructure.Constants.Discovery.VersionPath,
+            "provider version",
+            ct).ConfigureAwait(false);
+        var installed = await InspectEndpoint<OllamaTagsResponse>(
+            endpoint,
+            Infrastructure.Constants.Discovery.ModelsPath,
+            "installed models",
+            ct).ConfigureAwait(false);
+        var resident = await InspectEndpoint<OllamaTagsResponse>(
+            endpoint,
+            Infrastructure.Constants.Discovery.ResidentModelsPath,
+            "resident models",
+            ct).ConfigureAwait(false);
+
+        var versionValue = version.Value?.version;
+        versionValue = string.IsNullOrWhiteSpace(versionValue) ? null : versionValue.Trim();
+        var versionDetail = version.Succeeded && versionValue is null
+            ? "provider version inspection returned no version."
+            : version.Detail;
+        var details = new[] { versionDetail, installed.Detail, resident.Detail }
+            .Where(detail => !string.IsNullOrWhiteSpace(detail))
+            .ToArray();
+
+        return new AiSourceInspection
         {
-            using var lease = await AcquireConcurrencySlot(ct).ConfigureAwait(false);
-            var endpoint = GetHttpClientForRequest(candidate.Endpoint);
-            var models = MapModels(await FetchTags(endpoint, ct).ConfigureAwait(false));
-            return new AiSourceInspection
-            {
-                Provider = Type,
-                Endpoint = candidate.Endpoint,
-                Available = true,
-                Models = models.Select(model => model.Name).Where(name => name.Length > 0).ToArray(),
-                Capabilities = new HashSet<string>(Capabilities, StringComparer.OrdinalIgnoreCase)
-            };
-        }
-        catch (OperationCanceledException) when (ct.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            return new AiSourceInspection
-            {
-                Provider = Type,
-                Endpoint = candidate.Endpoint,
-                Available = false,
-                Capabilities = new HashSet<string>(Capabilities, StringComparer.OrdinalIgnoreCase),
-                Detail = ex.Message
-            };
-        }
+            Provider = Type,
+            Endpoint = candidate.Endpoint,
+            Available = version.Succeeded || installed.Succeeded || resident.Succeeded,
+            Version = versionValue,
+            VersionAvailable = versionValue is not null,
+            Models = MapModelNames(installed.Value),
+            ModelsAvailable = installed.Succeeded,
+            ResidentModels = MapModelNames(resident.Value),
+            ResidentModelsAvailable = resident.Succeeded,
+            Capabilities = new HashSet<string>(Capabilities, StringComparer.OrdinalIgnoreCase),
+            Detail = details.Length == 0 ? null : string.Join(" ", details)
+        };
     }
 
     private IReadOnlyList<AiModelDescriptor> MapModels(OllamaTagsResponse? doc)
@@ -292,7 +305,9 @@ internal sealed class OllamaAdapter : IChatAdapter, IEmbedAdapter, IAiSourceInsp
 
     private async Task<OllamaTagsResponse?> FetchTags(HttpClient http, CancellationToken ct)
     {
-        using var resp = await http.GetAsync("/api/tags", ct).ConfigureAwait(false);
+        using var resp = await http.GetAsync(
+            Infrastructure.Constants.Discovery.ModelsPath,
+            ct).ConfigureAwait(false);
         if (!resp.IsSuccessStatusCode)
         {
             var text = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
@@ -302,6 +317,54 @@ internal sealed class OllamaAdapter : IChatAdapter, IEmbedAdapter, IAiSourceInsp
 
         var json = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
         return JsonConvert.DeserializeObject<OllamaTagsResponse>(json);
+    }
+
+    private static IReadOnlyList<string> MapModelNames(OllamaTagsResponse? response)
+        => response?.models
+            .Select(model => model.name ?? model.model ?? "")
+            .Where(name => name.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray() ?? [];
+
+    private async Task<InspectionProbe<T>> InspectEndpoint<T>(
+        HttpClient http,
+        string path,
+        string facet,
+        CancellationToken ct)
+        where T : class
+    {
+        try
+        {
+            using var response = await http.GetAsync(path, ct).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                _logger.LogWarning(
+                    "Ollama: {Facet} inspection failed ({Status}) body={Body}",
+                    facet,
+                    (int)response.StatusCode,
+                    body);
+                return new InspectionProbe<T>(
+                    false,
+                    null,
+                    $"{facet} inspection returned HTTP {(int)response.StatusCode}.");
+            }
+
+            var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            var value = JsonConvert.DeserializeObject<T>(json);
+            return value is null
+                ? new InspectionProbe<T>(false, null, $"{facet} inspection returned no result.")
+                : new InspectionProbe<T>(true, value, null);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Ollama: {Facet} inspection failed", facet);
+            return new InspectionProbe<T>(false, null, $"{facet} inspection failed: {ex.Message}");
+        }
     }
 
     private HttpClient GetHttpClientForRequest(string? connectionString)
@@ -574,6 +637,11 @@ internal sealed class OllamaAdapter : IChatAdapter, IEmbedAdapter, IAiSourceInsp
         public float[]? embedding { get; set; }
     }
 
+    private sealed class OllamaVersionResponse
+    {
+        public string? version { get; set; }
+    }
+
     private sealed class OllamaTagsResponse
     {
         public List<OllamaTag> models { get; set; } = new();
@@ -584,4 +652,7 @@ internal sealed class OllamaAdapter : IChatAdapter, IEmbedAdapter, IAiSourceInsp
         public string? name { get; set; }
         public string? model { get; set; }
     }
+
+    private sealed record InspectionProbe<T>(bool Succeeded, T? Value, string? Detail)
+        where T : class;
 }

--- a/src/Connectors/AI/Ollama/README.md
+++ b/src/Connectors/AI/Ollama/README.md
@@ -68,6 +68,10 @@ when the functional Zen Garden engine is present and can satisfy the intent.
   may be elected.
 - Requests can select a model explicitly; otherwise `DefaultModel` is used.
 - Cancellation and provider HTTP failures propagate to the caller.
+- Runtime source inspection calls `/api/version`, `/api/tags`, and `/api/ps` inside this adapter. The provider-neutral
+  result reports version, installed models, and resident models without exposing Ollama transport to the application.
+  Each facet has its own availability flag, so an empty installed catalog or no resident models is not confused with
+  an unavailable endpoint.
 
 Koan does not install Ollama or pull the default model merely because this package is referenced. Model pull and
 removal remain explicit operations.

--- a/src/Connectors/AI/Ollama/TECHNICAL.md
+++ b/src/Connectors/AI/Ollama/TECHNICAL.md
@@ -31,6 +31,9 @@ endpoint election.
 - `AiPromptOptions.Think` is sent as Ollama's top-level `think` value.
 - Standard prompt controls map into Ollama's options object; `VendorOptions` are provider-specific passthrough values.
 - `MaxConcurrentRequests` bounds concurrent calls for this adapter when greater than zero.
+- Endpoint inspection independently calls `/api/version`, `/api/tags`, and `/api/ps`. The adapter maps those
+  responses to provider-neutral version, installed-model, and resident-model facets. Overall reachability succeeds
+  when any facet answers; per-facet availability and detail preserve partial failures.
 
 ## Boundaries
 

--- a/src/Koan.AI.Contracts/Sources/IAiSourceControl.cs
+++ b/src/Koan.AI.Contracts/Sources/IAiSourceControl.cs
@@ -36,8 +36,21 @@ public sealed record AiSourceInspection
 {
     public required string Provider { get; init; }
     public required string Endpoint { get; init; }
+    /// <summary>True when at least one provider-owned inspection facet answered successfully.</summary>
     public required bool Available { get; init; }
+    /// <summary>The provider runtime version, when its protocol exposes one.</summary>
+    public string? Version { get; init; }
+    /// <summary>True when the provider version was inspected successfully.</summary>
+    public bool VersionAvailable { get; init; }
+    /// <summary>Installed models. An empty collection is meaningful when <see cref="ModelsAvailable"/> is true.</summary>
     public IReadOnlyList<string> Models { get; init; } = [];
+    /// <summary>True when the installed-model catalog was inspected successfully.</summary>
+    public bool ModelsAvailable { get; init; }
+    /// <summary>Models currently resident in provider memory.</summary>
+    public IReadOnlyList<string> ResidentModels { get; init; } = [];
+    /// <summary>True when provider residency was inspected successfully.</summary>
+    public bool ResidentModelsAvailable { get; init; }
     public IReadOnlySet<string> Capabilities { get; init; } = new HashSet<string>();
+    /// <summary>Provider-neutral detail for unavailable or partially available inspection facets.</summary>
     public string? Detail { get; init; }
 }

--- a/src/Koan.AI/README.md
+++ b/src/Koan.AI/README.md
@@ -73,12 +73,24 @@ var inspection = await sourceControl.InspectAsync(new AiSourceCandidate
     Endpoint = "http://model-host:11434"
 });
 
+if (inspection.Available)
+{
+    Console.WriteLine(inspection.Version ?? "version unavailable");
+    Console.WriteLine($"Installed: {string.Join(", ", inspection.Models)}");
+    Console.WriteLine(inspection.ResidentModelsAvailable
+        ? $"Resident: {string.Join(", ", inspection.ResidentModels)}"
+        : "Residency unavailable");
+}
+
 sourceControl.Disable("maintenance-pool");
 sourceControl.Remove("retired-pool", expectedOrigin: "runtime");
 ```
 
-Ollama inspection calls its tags API; LM Studio inspection calls its OpenAI-compatible models API. Inspection does
-not register the endpoint. Disabled and removed sources leave routing and health probing immediately.
+`Available` means at least one provider-owned inspection facet answered. `VersionAvailable`,
+`ModelsAvailable`, and `ResidentModelsAvailable` distinguish unavailable facts from successful empty values;
+`Models` is the installed-model catalog. Ollama inspection owns its version, tags, and process APIs. LM Studio
+inspection owns its OpenAI-compatible models API and reports only the facets that protocol can inspect. Inspection
+does not register the endpoint. Disabled and removed sources leave routing and health probing immediately.
 
 ## Host and failure contract
 

--- a/src/Koan.AI/TECHNICAL.md
+++ b/src/Koan.AI/TECHNICAL.md
@@ -37,6 +37,11 @@ particular model is installed or healthy.
 Background health observation updates member state without rebuilding provider topology. Startup provenance reports
 configured categories/sources, the live adapter roster, and source/member status.
 
+`IAiSourceControl` coordinates runtime mutation and provider-owned endpoint inspection. `AiSourceInspection`
+separates overall reachability from version, installed-model, and resident-model facet availability. Successful
+empty collections therefore remain distinct from facets the provider could not inspect. Adapters own all transport
+and parsing; source control never becomes a provider client.
+
 `AiSourcesHealthContributor` composes as one element of the standard `IHealthContributor` collection and is
 noncritical by default. Its readiness data reports healthy, unhealthy, unknown, and recovering member counts.
 Unknown or recovering members are not false-green: an entirely unprobed source reports `unknown`, while a source

--- a/src/Koan.Jobs.Testing/Koan.Jobs.Testing.csproj
+++ b/src/Koan.Jobs.Testing/Koan.Jobs.Testing.csproj
@@ -4,6 +4,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
+    <PackageValidationBaselineVersion>0.20.1</PackageValidationBaselineVersion>
     <Description>Deterministically drive Koan Jobs through its production execution engine from any test framework.</Description>
     <PackageTags>$(CommonPackageTags);jobs;testing;deterministic;integration-testing</PackageTags>
   </PropertyGroup>

--- a/src/Koan.Web.Sse/Formatting/SseFormatter.cs
+++ b/src/Koan.Web.Sse/Formatting/SseFormatter.cs
@@ -23,7 +23,7 @@ public static class SseFormatter
             builder.Append(':').Append(' ').Append(envelope.Comment).Append('\n');
         }
 
-        if (envelope.HasEventName)
+        if (!envelope.IsControlFrame && envelope.HasEventName)
         {
             builder.Append("event: ").Append(envelope.EventName).Append('\n');
         }
@@ -40,7 +40,11 @@ public static class SseFormatter
                 .Append('\n');
         }
 
-        AppendDataLines(builder, envelope.Data);
+        if (!envelope.IsControlFrame)
+        {
+            AppendDataLines(builder, envelope.Data);
+        }
+
         builder.Append('\n');
         return builder.ToString();
     }

--- a/src/Koan.Web.Sse/README.md
+++ b/src/Koan.Web.Sse/README.md
@@ -52,6 +52,9 @@ Configure only the fallback event name when needed:
   and stop on request cancellation. Existing stronger cache or application-owned transport directives survive.
 - Typed and text values receive the explicit `Sse.Stream(..., eventName)` value or configured default. An explicit
   envelope remains unnamed unless the caller supplies `eventName`.
+- An envelope with empty data plus a comment, retry, or id is a control frame. It emits only those control fields,
+  even when the stream has a fallback event name; comment-only heartbeats are exactly `: text` plus the blank frame
+  terminator.
 - Empty text chunks are skipped; multiline data is emitted as valid repeated `data:` lines.
 - The package does not promise delivery, replay, resume storage, heartbeat generation, backpressure persistence,
   authentication, or proxy-specific buffering behavior. Compose those concerns at their owning transport or host.

--- a/src/Koan.Web.Sse/SseEnvelope.cs
+++ b/src/Koan.Web.Sse/SseEnvelope.cs
@@ -14,4 +14,7 @@ public readonly record struct SseEnvelope(
 {
     public bool HasEventName => !string.IsNullOrWhiteSpace(EventName);
     public bool HasComment => !string.IsNullOrWhiteSpace(Comment);
+    internal bool IsControlFrame =>
+        Data is { Length: 0 } &&
+        (HasComment || Retry is not null || !string.IsNullOrEmpty(Id));
 }

--- a/src/Koan.Web.Sse/TECHNICAL.md
+++ b/src/Koan.Web.Sse/TECHNICAL.md
@@ -22,6 +22,10 @@ The result applies its explicit event name as a fallback. `KoanSseOptions.Defaul
 projection only; an explicit unnamed envelope remains unnamed so comments and other control frames retain their
 protocol meaning. Explicit envelope event names always win.
 
+An envelope with empty data and at least one comment, retry, or id field is a control frame. Formatting suppresses
+both event and data fields for that frame, writes the supplied control fields, and terminates with one blank line.
+An empty envelope without control fields remains an empty data event. Null data remains invalid.
+
 ## Execution
 
 Execution resolves the host-owned `IOptions<KoanSseOptions>`, composes the SSE response headers, enumerates with

--- a/tests/Fixtures/AgentApplicationEngineering/README.md
+++ b/tests/Fixtures/AgentApplicationEngineering/README.md
@@ -9,3 +9,6 @@ matrix or repeat successful prompts.
 
 The fixtures contain no downstream application identity, path, URL, topology, or recognizable
 workflow.
+
+Latest retained run: [2026-07-23 cold-agent evidence](evidence/2026-07-23/README.md) — 3/3 prompts
+passed.

--- a/tests/Fixtures/AgentApplicationEngineering/evidence/2026-07-23/README.md
+++ b/tests/Fixtures/AgentApplicationEngineering/evidence/2026-07-23/README.md
@@ -1,0 +1,10 @@
+# Cold-agent evaluation — 2026-07-23
+
+Each prompt in `../../evaluations.json` ran once in an independent cold coding-agent context. The
+agent was told to read the public guide, follow public links only as needed, make no repository
+changes, and answer the prompt as a user-facing implementation response.
+
+The raw responses are retained beside `scores.json`. Scoring uses only the fixture's declared
+signals; it does not add a model matrix or repeat successful prompts.
+
+All three prompts passed.

--- a/tests/Fixtures/AgentApplicationEngineering/evidence/2026-07-23/brownfield.md
+++ b/tests/Fixtures/AgentApplicationEngineering/evidence/2026-07-23/brownfield.md
@@ -1,0 +1,135 @@
+I’d migrate this incrementally, keeping the public and operational contracts fixed while replacing the internals one slice at a time.
+
+The application intent is: users create, inspect, update, and delete reminders through the same HTTP contract, and due reminders are delivered reliably without changing deployment or configuration contracts.
+
+The initial Koan surface would be:
+
+```xml
+<PackageReference Include="Sylin.Koan.App" />
+<PackageReference Include="Sylin.Koan.Data.Connector.Mongo" />
+<PackageReference Include="Sylin.Koan.Jobs" />
+```
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddKoan();
+
+var app = builder.Build();
+
+// Keep the existing middleware, authentication, filters, and route setup.
+await app.RunAsync();
+```
+
+Koan 0.20 targets `net10.0`, so if the app is older, I would first upgrade the runtime and prove the unchanged API before introducing Koan behavior.
+
+The migration should proceed as follows:
+
+1. Freeze the current contract with tests covering every route and verb, request/response JSON, status code, headers, validation/problem details, authentication behavior, pagination, and environment key. Record the exact Mongo database, collection names, `_id` representation, BSON field names, indexes, TTL rules, and null/date serialization.
+
+2. Add `AddKoan()` and the package references without removing any existing controller, repository, hosted service, middleware, or deployment resource. Boot the real composed host and verify startup facts plus `/health/live` and `/health/ready`.
+
+3. Convert the persisted model to an Entity while pinning Mongo explicitly:
+
+```csharp
+[DataAdapter("mongo")]
+public sealed class Reminder : Entity<Reminder>
+{
+    public string Text { get; set; } = "";
+    public DateTimeOffset DueAt { get; set; }
+    public DateTimeOffset? DeliveredAt { get; set; }
+}
+```
+
+The actual key type and serialization must match the existing Mongo documents; use `Entity<Reminder, TKey>` if the current identifier is not Koan’s default string key. Do not cut over until a provider-level test proves that Koan reads and updates existing documents in the exact existing collection without rewriting their shape.
+
+4. Preserve the handwritten controllers initially. Replace only their repository calls with Entity operations:
+
+```csharp
+var reminder = await Reminder.Get(id, ct);
+var page = await Reminder.Page(pageNumber, pageSize, ct);
+await reminder.Save(ct);
+await reminder.Remove(ct);
+```
+
+Keep the existing DTOs and explicit mappings so payload names and shapes do not accidentally become persistence details. Keep every existing `[Route]`, `[HttpGet]`, `[HttpPost]`, authorization attribute, response mapping, and error contract. `EntityController<Reminder>` should replace a controller only if its complete HTTP contract is proven byte-for-byte compatible; routine CRUD similarity is not enough.
+
+5. Remove each repository only after all of its consumers use Entity operations and Mongo parity passes. Repository code that contains real application policy should be moved to a domain service or lifecycle rule, not deleted with the plumbing.
+
+6. Replace the hosted poller with durable Koan Jobs. A useful shape is a scheduled singleton sweep that finds due reminders and submits pointwise delivery work:
+
+```csharp
+public static class ReminderActions
+{
+    public const string Deliver = nameof(Deliver);
+    public const string Sweep = nameof(Sweep);
+}
+
+[DataAdapter("mongo")]
+[JobIdempotent(nameof(Id), nameof(DueAt))]
+public sealed class Reminder : Entity<Reminder>, IKoanJob<Reminder>
+{
+    // Existing persisted fields remain unchanged.
+
+    public static async Task Execute(
+        Reminder reminder,
+        JobContext context,
+        CancellationToken ct)
+    {
+        if (context.Action != ReminderActions.Deliver)
+            return;
+
+        if (reminder.DeliveredAt is not null)
+            return;
+
+        var sender = context.Services.GetRequiredService<IReminderSender>();
+        await sender.Send(reminder, idempotencyKey: $"{reminder.Id}:{reminder.DueAt:O}", ct);
+
+        reminder.DeliveredAt = DateTimeOffset.UtcNow;
+    }
+}
+```
+
+The sweep should use bounded paging or Mongo-backed `QueryStream`, never an unbounded `All()`, and submit `ReminderActions.Deliver` for due items. If the existing polling interval comes from an environment key, bind that same key to a typed `ReminderPollingOptions`; use a boot-triggered sweep that calls `context.Reschedule(options.Interval)` so no deployment key is renamed or hard-coded.
+
+Mark durable work with:
+
+```csharp
+[JobPersistence(JobPersistenceMode.DataStore)]
+```
+
+That makes missing durable Mongo infrastructure a composition failure instead of silently degrading to an in-memory queue. Jobs provides durable ledger acceptance, restart survival with Mongo, competing consumers across replicas, retries, and at-least-once execution. The application still owns idempotent delivery because no framework can make an external notification exactly-once merely by retrying it.
+
+Preserve the environment contract by translating the existing keys in-process rather than changing manifests:
+
+```csharp
+builder.Configuration["ConnectionStrings:Mongo"] =
+    builder.Configuration[ExistingKeys.MongoConnection]
+    ?? throw new InvalidOperationException(
+        $"{ExistingKeys.MongoConnection} is required.");
+
+builder.Configuration["Koan:Data:Mongo:Database"] =
+    builder.Configuration[ExistingKeys.MongoDatabase]
+    ?? throw new InvalidOperationException(
+        $"{ExistingKeys.MongoDatabase} is required.");
+```
+
+`ExistingKeys` should contain the app’s real current key names. Secrets remain in the existing platform secret store. Docker Compose, Aspire, or Kubernetes continues to provision the same app and Mongo containers; Koan discovers and monitors them but does not replace the topology.
+
+Before removing the old mechanisms, I would require these proofs:
+
+| Intent | Old owner | New owner | Required proof |
+|---|---|---|---|
+| HTTP compatibility | Handwritten CRUD plus repositories | Same controllers plus Entity operations | Golden HTTP contract tests |
+| Existing Mongo data | Repository/driver setup | Koan Mongo connector | Read/update/delete against a production-shaped clone, including key and collection mapping |
+| Polling and delivery | Hosted service | Koan Jobs plus application sender | Due selection, restart recovery, retry, duplicate execution, and multi-replica tests |
+| Configuration | Existing environment keys | Application aliasing into Koan config | Boot using unchanged manifests and key names |
+| Deployment | Existing Compose/Aspire/Kubernetes | Unchanged | Same services, ports, volumes, networks, and replica behavior |
+
+Two issues must fail the migration safely rather than being guessed around:
+
+- If Koan’s public Mongo configuration cannot pin the current collection/key representation exactly, keep the repository for that entity and reduce the mismatch to a focused framework reproduction.
+- Durable Jobs will add its ledger and supporting indexes/TTL data to Mongo. If the existing database is not allowed to gain framework-owned collections, decide explicitly whether the ledger may use a separate named Mongo source or whether the hosted poller must remain.
+
+Only after all four boundaries pass would I delete the repository registrations, Mongo driver bootstrap, hosted poller, and their duplicate health checks.

--- a/tests/Fixtures/AgentApplicationEngineering/evidence/2026-07-23/corrective.md
+++ b/tests/Fixtures/AgentApplicationEngineering/evidence/2026-07-23/corrective.md
@@ -1,0 +1,23 @@
+Reference `Sylin.Koan.Jobs`, define the work as an Entity implementing `IKoanJob<T>`, and explicitly require durable persistence:
+
+```csharp
+[JobPersistence(JobPersistenceMode.DataStore)]
+public sealed class SendDigest : Entity<SendDigest>, IKoanJob<SendDigest>
+{
+    public static Task Execute(
+        SendDigest job,
+        JobContext context,
+        CancellationToken ct) => /* idempotent work */;
+}
+
+await new SendDigest().Job.Submit();
+```
+
+Keep the normal `AddKoan()` call; Jobs needs no manual registration. To satisfy `DataStore`, also reference and configure a durable Koan Data provider such as SQLite, PostgreSQL, SQL Server, or MongoDB.
+
+The failure behavior is intentional:
+
+- Without `[JobPersistence(DataStore)]`, the host starts using the automatic in-memory ledger. Jobs can retry and remain inspectable only for that process lifetime; queued work and history are lost on restart.
+- With `[JobPersistence(DataStore)]`, composition fails at startup when no durable Data provider is available. Koan reports that the durability requirement cannot be honored and directs the operator to add a qualifying provider or relax the requirement; it never silently downgrades declared durable work to memory.
+
+Execution remains at-least-once even with durable storage, so externally visible effects must be idempotent.

--- a/tests/Fixtures/AgentApplicationEngineering/evidence/2026-07-23/greenfield.md
+++ b/tests/Fixtures/AgentApplicationEngineering/evidence/2026-07-23/greenfield.md
@@ -1,0 +1,129 @@
+A checkout should atomically persist the loan and accept a durable notice job for execution after its due date. Use the `koan-web` template, which includes SQLite, and add `Sylin.Koan.Jobs`.
+
+```csharp
+[JobPersistence(JobPersistenceMode.DataStore)]
+[JobAction(SendNotice, MaxAttempts = 5, Timeout = "00:00:30")]
+public sealed class Loan : Entity<Loan>, IKoanJob<Loan>
+{
+    public const string SendNotice = nameof(SendNotice);
+
+    public string BookId { get; set; } = "";
+    public string BorrowerId { get; set; } = "";
+    public DateTimeOffset DueAt { get; set; }
+    public DateTimeOffset? ReturnedAt { get; set; }
+    public DateTimeOffset? NoticeSentAt { get; set; }
+
+    public static async Task Execute(
+        Loan loan,
+        JobContext context,
+        CancellationToken ct)
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        if (loan.ReturnedAt is not null || loan.NoticeSentAt is not null)
+            return;
+
+        if (now < loan.DueAt)
+        {
+            context.Reschedule(loan.DueAt);
+            return;
+        }
+
+        var notices =
+            context.Services.GetRequiredService<IOverdueNoticeSender>();
+
+        // The loan ID is the external idempotency key because Jobs is at-least-once.
+        await notices.SendOnce(loan.Id, loan.BorrowerId, loan.BookId, ct);
+
+        loan.NoticeSentAt = now; // Koan saves mutations made to the job Entity.
+        await context.Progress(1, "Overdue notice sent");
+    }
+}
+```
+
+Expose the business actions directly:
+
+```csharp
+public sealed record CheckoutLoan(
+    string BookId,
+    string BorrowerId,
+    DateTimeOffset DueAt);
+
+[ApiController]
+[Route("api/loans")]
+public sealed class LoansController : ControllerBase
+{
+    [HttpPost]
+    public async Task<ActionResult<Loan>> Checkout(
+        CheckoutLoan request,
+        CancellationToken ct)
+    {
+        if (request.DueAt <= DateTimeOffset.UtcNow)
+            return BadRequest("dueAt must be in the future.");
+
+        var loan = new Loan
+        {
+            BookId = request.BookId,
+            BorrowerId = request.BorrowerId,
+            DueAt = request.DueAt
+        };
+
+        using (EntityContext.Transaction("checkout"))
+        {
+            await loan.Save(ct);
+
+            await loan.Job.Submit(
+                Loan.SendNotice,
+                after: request.DueAt - DateTimeOffset.UtcNow);
+
+            await EntityContext.Commit();
+        }
+
+        return AcceptedAtAction(nameof(Get), new { id = loan.Id }, loan);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<Loan>> Get(string id, CancellationToken ct)
+    {
+        var loan = await Loan.Get(id, ct);
+        return loan is null ? NotFound() : Ok(loan);
+    }
+
+    [HttpPost("{id}/return")]
+    public async Task<ActionResult<Loan>> Return(string id, CancellationToken ct)
+    {
+        var loan = await Loan.Get(id, ct);
+        if (loan is null)
+            return NotFound();
+
+        loan.ReturnedAt = DateTimeOffset.UtcNow;
+        await loan.Save(ct);
+        await loan.Job.Cancel();
+
+        return Ok(loan);
+    }
+
+    [HttpGet("{id}/notice-status")]
+    public async Task<ActionResult<JobStatus?>> NoticeStatus(
+        string id,
+        CancellationToken ct)
+    {
+        var loan = await Loan.Get(id, ct);
+        return loan is null ? NotFound() : Ok(await loan.Job.Status());
+    }
+}
+```
+
+The host remains ordinary Koan composition:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddKoan();
+builder.Services.AddScoped<IOverdueNoticeSender, EmailOverdueNoticeSender>();
+
+var app = builder.Build();
+await app.RunAsync();
+```
+
+SQLite owns durable loan and job-ledger storage; Jobs owns acceptance, deferred execution, retries, and inspection. The transaction prevents a persisted loan without its corresponding job. `[JobPersistence(DataStore)]` makes startup fail if a durable Data provider is missing. `Submit` confirms ledger acceptance, not delivery, and the application-owned sender must honor the loan ID idempotency key because execution is at-least-once. No repository, `DbContext`, hosted worker, queue registration, or Jobs-specific registration is required.

--- a/tests/Fixtures/AgentApplicationEngineering/evidence/2026-07-23/scores.json
+++ b/tests/Fixtures/AgentApplicationEngineering/evidence/2026-07-23/scores.json
@@ -1,0 +1,102 @@
+{
+  "schemaVersion": 1,
+  "capturedAt": "2026-07-23",
+  "protocol": "one independent cold-agent run per prompt",
+  "guide": "docs/guides/agent-application-engineering.md",
+  "fixture": "tests/Fixtures/AgentApplicationEngineering/evaluations.json",
+  "results": [
+    {
+      "id": "greenfield",
+      "rawOutput": "greenfield.md",
+      "passed": true,
+      "signals": [
+        {
+          "signal": "states application intent before implementation",
+          "passed": true,
+          "evidence": "Opens with the atomic loan and durable overdue-notice outcome."
+        },
+        {
+          "signal": "uses Entity<T> and standard Entity operations",
+          "passed": true,
+          "evidence": "Defines Loan : Entity<Loan> and uses Save, Get, and Entity-owned job operations."
+        },
+        {
+          "signal": "uses Jobs for Entity-owned background work",
+          "passed": true,
+          "evidence": "Loan implements IKoanJob<Loan> and submits its notice action."
+        },
+        {
+          "signal": "names package and durability boundary",
+          "passed": true,
+          "evidence": "Names Sylin.Koan.Jobs, SQLite, DataStore persistence, and at-least-once execution."
+        },
+        {
+          "signal": "proposes focused behavior, composition, and corrective proof",
+          "passed": true,
+          "evidence": "Covers the checkout behavior, AddKoan host composition, and missing durable-provider startup failure."
+        }
+      ]
+    },
+    {
+      "id": "brownfield",
+      "rawOutput": "brownfield.md",
+      "passed": true,
+      "signals": [
+        {
+          "signal": "preserves observable integration contracts",
+          "passed": true,
+          "evidence": "Freezes HTTP, Mongo, deployment, and environment contracts before replacement."
+        },
+        {
+          "signal": "classifies mechanisms as keep, absorb, rebuild, or delete",
+          "passed": true,
+          "evidence": "Keeps controllers and policy initially, absorbs persistence and work, and deletes duplicates only after proof."
+        },
+        {
+          "signal": "moves persistence and CRUD to Entity<T> surfaces",
+          "passed": true,
+          "evidence": "Introduces Reminder : Entity<Reminder> and replaces repository calls with Entity operations."
+        },
+        {
+          "signal": "moves background work only after naming its guarantee",
+          "passed": true,
+          "evidence": "Names durable acceptance, restart survival, retries, and at-least-once execution before replacing polling."
+        },
+        {
+          "signal": "migrates and proves one mechanism at a time",
+          "passed": true,
+          "evidence": "Uses staged cutover with HTTP, Mongo, Jobs, configuration, and deployment proofs."
+        }
+      ]
+    },
+    {
+      "id": "corrective",
+      "rawOutput": "corrective.md",
+      "passed": true,
+      "signals": [
+        {
+          "signal": "does not invent Jobs registration",
+          "passed": true,
+          "evidence": "Keeps AddKoan and explicitly says Jobs needs no manual registration."
+        },
+        {
+          "signal": "distinguishes in-memory convenience from durable restart survival",
+          "passed": true,
+          "evidence": "Explains process-lifetime in-memory behavior separately from DataStore persistence."
+        },
+        {
+          "signal": "requires a durable Data provider for the durability claim",
+          "passed": true,
+          "evidence": "Requires a qualifying durable Data provider for DataStore persistence."
+        },
+        {
+          "signal": "expects a corrective composition failure for explicitly required durability",
+          "passed": true,
+          "evidence": "States that host composition fails instead of silently downgrading."
+        }
+      ]
+    }
+  ],
+  "passed": 3,
+  "failed": 0
+}

--- a/tests/Koan.Web.Sse.Tests/SseStreamTests.cs
+++ b/tests/Koan.Web.Sse.Tests/SseStreamTests.cs
@@ -54,6 +54,34 @@ public sealed class SseStreamTests
     }
 
     [Fact]
+    public void Formatter_emits_the_exact_comment_only_control_frame()
+    {
+        var formatted = SseFormatter.ToWireFormat(
+            new SseEnvelope(null, "", Comment: "hb"));
+
+        formatted.Should().Be(": hb\n\n");
+    }
+
+    [Fact]
+    public void Formatter_emits_the_exact_retry_only_control_frame()
+    {
+        var formatted = SseFormatter.ToWireFormat(
+            new SseEnvelope(null, "", Retry: TimeSpan.FromSeconds(2)));
+
+        formatted.Should().Be("retry: 2000\n\n");
+    }
+
+    [Fact]
+    public void Formatter_rejects_null_data()
+    {
+        var envelope = new SseEnvelope(null, null!);
+
+        var act = () => SseFormatter.ToWireFormat(envelope);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
     public async Task The_same_result_executes_through_mvc()
     {
         var context = CreateHttpContext();
@@ -89,6 +117,27 @@ public sealed class SseStreamTests
         var payload = await ReadBody(context);
         payload.Should().Contain("event: requested").And.Contain("event: custom");
         payload.Should().NotContain("event: configured");
+    }
+
+    [Fact]
+    public async Task Minimal_result_preserves_exact_control_frames_even_with_a_requested_fallback()
+    {
+        var context = CreateHttpContext();
+
+        await Sse.Stream(GetControlFrames(), eventName: "fallback").ExecuteAsync(context);
+
+        (await ReadBody(context)).Should().Be(": hb\n\nretry: 1500\n\n: warm\nretry: 3000\n\n");
+    }
+
+    [Fact]
+    public async Task Mvc_result_preserves_exact_control_frames()
+    {
+        var context = CreateHttpContext();
+        IActionResult result = Sse.Stream(GetControlFrames());
+
+        await result.ExecuteResultAsync(new ActionContext(context, new RouteData(), new ActionDescriptor()));
+
+        (await ReadBody(context)).Should().Be(": hb\n\nretry: 1500\n\n: warm\nretry: 3000\n\n");
     }
 
     [Fact]
@@ -158,6 +207,18 @@ public sealed class SseStreamTests
         yield return new SseEnvelope(null, "noop");
         await Task.Yield();
         yield return new SseEnvelope("custom", "data");
+    }
+
+    private static async IAsyncEnumerable<SseEnvelope> GetControlFrames()
+    {
+        yield return new SseEnvelope(null, "", Comment: "hb");
+        await Task.Yield();
+        yield return new SseEnvelope(null, "", Retry: TimeSpan.FromMilliseconds(1500));
+        yield return new SseEnvelope(
+            "ignored-for-control",
+            "",
+            Retry: TimeSpan.FromSeconds(3),
+            Comment: "warm");
     }
 
     private sealed class TestMessage

--- a/tests/Suites/AI/Unit/Koan.Tests.AI.Unit/Specs/Adapters/OllamaAdapter.Spec.cs
+++ b/tests/Suites/AI/Unit/Koan.Tests.AI.Unit/Specs/Adapters/OllamaAdapter.Spec.cs
@@ -104,8 +104,13 @@ public sealed class OllamaAdapterSpec
     {
         var handler = new RecordingHandler((request, _) =>
         {
-            request.RequestUri!.AbsolutePath.Should().Be("/api/tags");
-            return JsonResponse("""{"models":[{"name":"phi3:mini","model":"phi3"}]}""");
+            return request.RequestUri!.AbsolutePath switch
+            {
+                "/api/version" => JsonResponse("""{"version":"0.11.4"}"""),
+                "/api/tags" => JsonResponse("""{"models":[{"name":"phi3:mini","model":"phi3"}]}"""),
+                "/api/ps" => JsonResponse("""{"models":[{"name":"phi3:mini","model":"phi3"}]}"""),
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound)
+            };
         });
         using var adapter = CreateAdapter(handler);
 
@@ -116,8 +121,64 @@ public sealed class OllamaAdapterSpec
         });
 
         result.Available.Should().BeTrue();
+        result.VersionAvailable.Should().BeTrue();
+        result.Version.Should().Be("0.11.4");
+        result.ModelsAvailable.Should().BeTrue();
         result.Models.Should().Equal("phi3:mini");
+        result.ResidentModelsAvailable.Should().BeTrue();
+        result.ResidentModels.Should().Equal("phi3:mini");
         result.Capabilities.Should().Contain("Chat");
+        handler.Requests.Select(request => request.Uri.AbsolutePath)
+            .Should().Equal("/api/version", "/api/tags", "/api/ps");
+    }
+
+    [Fact]
+    public async Task Inspection_distinguishes_an_empty_catalog_from_unavailable_residency()
+    {
+        var handler = new RecordingHandler((request, _) =>
+            request.RequestUri!.AbsolutePath switch
+            {
+                "/api/version" => JsonResponse("""{"version":"0.11.4"}"""),
+                "/api/tags" => JsonResponse("""{"models":[]}"""),
+                "/api/ps" => new HttpResponseMessage(HttpStatusCode.ServiceUnavailable),
+                _ => new HttpResponseMessage(HttpStatusCode.NotFound)
+            });
+        using var adapter = CreateAdapter(handler);
+
+        var result = await adapter.InspectAsync(new AiSourceCandidate
+        {
+            Provider = "ollama",
+            Endpoint = "http://localhost:11434"
+        });
+
+        result.Available.Should().BeTrue();
+        result.ModelsAvailable.Should().BeTrue();
+        result.Models.Should().BeEmpty();
+        result.ResidentModelsAvailable.Should().BeFalse();
+        result.ResidentModels.Should().BeEmpty();
+        result.Detail.Should().Contain("resident models").And.Contain("503");
+    }
+
+    [Fact]
+    public async Task Inspection_reports_unreachable_when_no_provider_facet_answers()
+    {
+        var handler = new RecordingHandler((_, _) =>
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        using var adapter = CreateAdapter(handler);
+
+        var result = await adapter.InspectAsync(new AiSourceCandidate
+        {
+            Provider = "ollama",
+            Endpoint = "http://localhost:11434"
+        });
+
+        result.Available.Should().BeFalse();
+        result.VersionAvailable.Should().BeFalse();
+        result.ModelsAvailable.Should().BeFalse();
+        result.ResidentModelsAvailable.Should().BeFalse();
+        result.Detail.Should().Contain("provider version").And
+            .Contain("installed models").And
+            .Contain("resident models");
     }
 
     private static OllamaAdapter CreateAdapter(RecordingHandler handler, string model = "phi3")

--- a/tests/Suites/AI/Unit/Koan.Tests.AI.Unit/Specs/Routing/AiSourceRuntimeLifecycle.Spec.cs
+++ b/tests/Suites/AI/Unit/Koan.Tests.AI.Unit/Specs/Routing/AiSourceRuntimeLifecycle.Spec.cs
@@ -51,6 +51,25 @@ public sealed class AiSourceRuntimeLifecycleSpec
     }
 
     [Fact]
+    public void A_late_health_result_cannot_resurrect_a_removed_source()
+    {
+        var registry = new AiSourceRegistry();
+        var runtime = (IAiSourceRuntimeRegistry)registry;
+        runtime.Apply(Source("local", "runtime"));
+        var removed = runtime.GetRuntimeSources().Single();
+
+        runtime.Remove("local", expectedOrigin: "runtime").Should().BeTrue();
+
+        runtime.TrySetMemberHealth(
+                removed.Source.Name,
+                removed.Revision,
+                removed.Source.Members.Single().Name,
+                MemberHealthState.Healthy)
+            .Should().BeFalse();
+        registry.HasSource("local").Should().BeFalse();
+    }
+
+    [Fact]
     public void AddAi_exposes_the_runtime_control_plane_without_extra_registration()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
## What changed

- emit exact SSE comment/retry control frames without synthetic event or data fields
- extend provider-owned AI inspection with version, installed-model, and resident-model facets
- make the Ollama adapter own `/api/version`, `/api/tags`, and `/api/ps`, including partial-failure semantics
- prove stale source results cannot mutate replaced or removed runtime sources
- retain and score the three anonymous cold-agent runs required by ARCH-0122
- record the now-published `Sylin.Koan.Jobs.Testing` 0.20.1 API baseline

## Why

The first dogfood closure fixed runtime lifecycle ownership but left two observable gaps: control-only SSE envelopes still gained an empty data field, and applications still needed provider-specific Ollama probing for version and residency. This closes those guarantees at their framework owners without adding another registry, client, or certification system.

## Impact

Existing calls remain valid. `AiSourceInspection` now exposes facet availability so an unavailable probe is distinguishable from a successful empty model collection. Ollama consumers can remove duplicate provider clients after the corrected packages publish.

## Validation

- Koan.Web.Sse.Tests: 13/13
- Koan.Tests.AI.Unit: 173/173
- supported API baselines: 77/77
- generated product surface current
- documentation lint: 0 errors
- skill lint: 0 errors, 0 warnings
- anonymous cold-agent fixtures: 3/3
- private-identity and retired-comparison scans clean

The local whole-repository coherence wrapper reached a sandbox-blocked NuGet restore; the pull-request gate remains the authoritative clean-environment build and lint run.