### PR TITLE
Compose explicit AI source and model routing

### DIFF
--- a/docs/decisions/ARCH-0122-dogfood-runtime-and-test-seams.md
+++ b/docs/decisions/ARCH-0122-dogfood-runtime-and-test-seams.md
@@ -17,11 +17,12 @@ related:
 
 ## Outcome
 
-Koan closes three application-facing gaps found through brownfield use:
+Koan closes four application-facing gaps found through brownfield use:
 
 1. SSE preserves the caller's protocol intent and composes with stronger HTTP cache policy.
 2. AI sources can be inspected and changed at runtime through one source-lifecycle owner.
 3. Jobs exposes an xUnit-free deterministic driver over the production execution engine.
+4. Explicit AI source or member selection composes with explicit model selection without fallback.
 
 A concise agent workflow teaches how to find and prove those expressions. It links to the canonical
 capability guides rather than becoming another framework curriculum.
@@ -36,6 +37,8 @@ An engineer or coding agent can discover those paths quickly for greenfield or b
 comment, retry, or id fields is an exact control frame. AI exposes `IAiSourceControl` with inspect,
 apply, enable, disable, and remove operations while ordinary routing remains automatic. Inspection
 reports provider version, installed models, and resident models without exposing a provider client.
+An advanced request selects a logical source with `WithSource` or `AiRouteHints.Source`; it may
+compose that choice with `WithModel` and may pin one member using `source::member`.
 `JobsTestDriver.From(services)` drives the existing Jobs engine after the host opts out of background
 execution. The agent workflow uses the normal package, configuration, Entity, context, and runtime
 surfaces documented by each capability pillar.
@@ -98,13 +101,18 @@ provider-owned inspection request; partial failures remain visible in `Detail`.
 Ollama owns `/api/version`, `/api/tags`, and `/api/ps`. The application neither calls nor parses those
 endpoints. Other providers populate only the facets their protocol can truthfully inspect.
 
-### Route-hint naming clarification
+### Explicit AI route composition
 
-`WithRouteAdapter` currently carries a source or member hint; the router resolves the actual provider
-adapter from that source. This decision does not add a source-named alias because two names for one
-route field would make the public path less clear. A later semantic rename must change
-`AiRouteHints.AdapterId` and its fluent method together, with one compatibility decision, rather than
-layering another permanent synonym into this closure.
+The application selects a logical source, not a provider adapter. `AiRouteHints.Source` and
+`WithSource` are therefore the canonical public expression. The existing `AdapterId` property and
+`WithRouteAdapter` method remain compatibility aliases that carry the same value; current
+documentation does not teach them. The router still resolves the provider adapter from the selected
+source, so no second route field, registry, or resolution path is introduced.
+
+Source, member, and model are orthogonal request decisions. An explicit source or member is resolved
+before model-driven election. Capability validation then applies to that exact choice. Missing,
+disabled, and capability-incompatible choices report usable alternatives, while source-free requests
+retain automatic capability and priority election, including the existing model-only fallback.
 
 ### Deterministic Jobs testing
 
@@ -128,6 +136,7 @@ retrieval evaluation. They do not encode a private application, infrastructure t
 ### Positive
 
 - Applications stop working around missing lifecycle and testing seams.
+- Source and model intent compose without silently changing either decision.
 - Provider integrations remain unchanged and continue to own their protocols.
 - The public Jobs surface grows by a driver, not by exposing the engine's internals.
 - Agent guidance becomes a routing and reasoning aid rather than duplicated documentation.
@@ -138,6 +147,8 @@ retrieval evaluation. They do not encode a private application, infrastructure t
 - AI source mutation requires revision-aware registry and health-monitor coordination.
 - Provider-specific inspection is available only when an adapter implements the inspection contract;
   unsupported providers reject the request correctively.
+- Adapter-named route members remain temporarily visible for compatibility, although source-named
+  members are the only current path taught.
 - Deterministic Jobs tests must deliberately disable the background worker.
 
 ## Evidence boundary

--- a/src/Koan.AI.Contracts/Models/AiRouteHints.cs
+++ b/src/Koan.AI.Contracts/Models/AiRouteHints.cs
@@ -1,8 +1,31 @@
+using System.ComponentModel;
+
 namespace Koan.AI.Contracts.Models;
 
 public record AiRouteHints
 {
-    public string? AdapterId { get; init; }
+    private string? _source;
+
+    /// <summary>
+    /// Logical source name, or a pinned member in <c>source::member</c> form.
+    /// </summary>
+    public string? Source
+    {
+        get => _source;
+        init => _source = value;
+    }
+
+    /// <summary>
+    /// Compatibility alias for <see cref="Source"/>. Applications select a source; the router
+    /// resolves its provider adapter.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public string? AdapterId
+    {
+        get => _source;
+        init => _source = value;
+    }
+
     public string? Policy { get; init; }
     public string? StickyKey { get; init; }
 }

--- a/src/Koan.AI/AiConversationBuilder.cs
+++ b/src/Koan.AI/AiConversationBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -125,12 +126,16 @@ public sealed class AiConversationBuilder
         return this;
     }
 
-    public AiConversationBuilder WithRouteAdapter(string adapterId)
+    public AiConversationBuilder WithSource(string source)
     {
-        if (string.IsNullOrWhiteSpace(adapterId)) throw new ArgumentException("Adapter ID is required.", nameof(adapterId));
-        _route = (_route ?? new AiRouteHints()) with { AdapterId = adapterId.Trim() };
+        if (string.IsNullOrWhiteSpace(source)) throw new ArgumentException("Source is required.", nameof(source));
+        _route = (_route ?? new AiRouteHints()) with { Source = source.Trim() };
         return this;
     }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public AiConversationBuilder WithRouteAdapter(string adapterId)
+        => WithSource(adapterId);
 
     public AiConversationBuilder WithRoutePolicy(string policy)
     {

--- a/src/Koan.AI/Client.cs
+++ b/src/Koan.AI/Client.cs
@@ -1524,7 +1524,7 @@ public static class Client
             Model = model,
             Options = promptOpts,
             Route = scopeSource is not null
-                ? new AiRouteHints { AdapterId = scopeSource }
+                ? new AiRouteHints { Source = scopeSource }
                 : null
         };
     }

--- a/src/Koan.AI/Pipeline/AiCategoryRouter.cs
+++ b/src/Koan.AI/Pipeline/AiCategoryRouter.cs
@@ -103,10 +103,13 @@ internal sealed class AiCategoryRouter
             return Resolve(via, effectiveSource, effectiveModel);
         }
 
-        var source = ResolveSource(effectiveSource, MapCategoryToCapability(category), effectiveModel);
-        var member = SelectMember(source, effectiveSource);
+        var capability = MapCategoryToCapability(category);
+        var source = ResolveSource(effectiveSource, capability, effectiveModel);
+        var requireMemberCapability =
+            !string.IsNullOrWhiteSpace(effectiveSource) || string.IsNullOrWhiteSpace(effectiveModel);
+        var member = SelectMember(source, effectiveSource, capability, requireMemberCapability);
         var adapter = ResolveAdapter(source);
-        var resolvedModel = DetermineEffectiveModel(source, member, MapCategoryToCapability(category), effectiveModel);
+        var resolvedModel = DetermineEffectiveModel(source, member, capability, effectiveModel);
 
         return new AiRouteResolution(source, member, adapter, category, resolvedModel);
     }
@@ -150,7 +153,7 @@ internal sealed class AiCategoryRouter
             }
         }
 
-        return Resolve(AiCapability.Chat, request.Route?.AdapterId, modelHint);
+        return Resolve(AiCapability.Chat, request.Route?.Source, modelHint);
     }
 
     /// <summary>
@@ -196,6 +199,37 @@ internal sealed class AiCategoryRouter
 
     private AiSourceDefinition ResolveSource(string? sourceHint, string capabilityName, string? explicitModel)
     {
+        if (!string.IsNullOrWhiteSpace(sourceHint))
+        {
+            var sourceName = GetSourceName(sourceHint);
+            var source = _sourceRegistry.GetSource(sourceName);
+            if (source is null)
+            {
+                var memberContext = sourceHint.Contains("::", StringComparison.Ordinal)
+                    ? $" for member reference '{sourceHint}'"
+                    : string.Empty;
+                throw new InvalidOperationException(
+                    $"Source '{sourceName}' not found{memberContext}. " +
+                    $"Usable sources for capability '{capabilityName}': {FormatChoices(GetUsableSourceNames(capabilityName))}");
+            }
+
+            if (!source.IsEnabled)
+            {
+                throw new InvalidOperationException(
+                    $"AI source '{source.Name}' is disabled. Enable it through IAiSourceControl or select another source. " +
+                    $"Usable sources for capability '{capabilityName}': {FormatChoices(GetUsableSourceNames(capabilityName))}");
+            }
+
+            if (!SupportsCapability(source, capabilityName))
+            {
+                throw new InvalidOperationException(
+                    $"Source '{source.Name}' does not support capability '{capabilityName}'. " +
+                    $"Usable sources: {FormatChoices(GetUsableSourceNames(capabilityName))}");
+            }
+
+            return source;
+        }
+
         if (!string.IsNullOrWhiteSpace(explicitModel))
         {
             var capabilitySources = _sourceRegistry.GetSourcesWithCapability(capabilityName);
@@ -216,27 +250,6 @@ internal sealed class AiCategoryRouter
                 "No AI sources available. Configure an adapter (e.g. Ollama) or enable discovery.");
         }
 
-        if (!string.IsNullOrWhiteSpace(sourceHint))
-        {
-            var source = _sourceRegistry.GetSource(sourceHint);
-            if (source is not null) return RequireEnabled(source);
-
-            if (sourceHint.Contains("::", StringComparison.Ordinal))
-            {
-                var sourceName = sourceHint.Split("::")[0];
-                source = _sourceRegistry.GetSource(sourceName);
-                if (source is not null) return RequireEnabled(source);
-
-                throw new InvalidOperationException(
-                    $"Source '{sourceName}' not found for member reference '{sourceHint}'. " +
-                    $"Available sources: {string.Join(", ", _sourceRegistry.GetSourceNames())}");
-            }
-
-            throw new InvalidOperationException(
-                $"Source '{sourceHint}' not found. " +
-                $"Available sources: {string.Join(", ", _sourceRegistry.GetSourceNames())}");
-        }
-
         var candidates = _sourceRegistry.GetSourcesWithCapability(capabilityName);
         if (candidates.Count == 0)
         {
@@ -247,14 +260,40 @@ internal sealed class AiCategoryRouter
         return candidates.First();
     }
 
-    private static AiSourceDefinition RequireEnabled(AiSourceDefinition source)
+    private IReadOnlyList<string> GetUsableSourceNames(string capabilityName)
+        => _sourceRegistry.GetAllSources()
+            .Where(source => source.IsEnabled && SupportsCapability(source, capabilityName))
+            .OrderByDescending(source => source.Priority)
+            .ThenBy(source => source.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(source => source.Name)
+            .ToArray();
+
+    private static bool SupportsCapability(AiSourceDefinition source, string capabilityName)
     {
-        if (source.IsEnabled) return source;
-        throw new InvalidOperationException(
-            $"AI source '{source.Name}' is disabled. Enable it through IAiSourceControl or select another source.");
+        if (source.Members.Count == 0)
+            return source.Capabilities.ContainsKey(capabilityName);
+
+        return source.Members.Any(member =>
+            source.GetEffectiveCapabilities(member).ContainsKey(capabilityName));
     }
 
-    private static AiMemberDefinition SelectMember(AiSourceDefinition source, string? sourceHint)
+    private static string GetSourceName(string sourceHint)
+    {
+        var separator = sourceHint.IndexOf("::", StringComparison.Ordinal);
+        return separator < 0 ? sourceHint : sourceHint[..separator];
+    }
+
+    private static string FormatChoices(IEnumerable<string> choices)
+    {
+        var values = choices.ToArray();
+        return values.Length == 0 ? "(none)" : string.Join(", ", values);
+    }
+
+    private static AiMemberDefinition SelectMember(
+        AiSourceDefinition source,
+        string? sourceHint,
+        string capabilityName,
+        bool requireCapability)
     {
         if (source is null) throw new ArgumentNullException(nameof(source));
 
@@ -267,7 +306,17 @@ internal sealed class AiCategoryRouter
             {
                 throw new InvalidOperationException(
                     $"Member '{sourceHint}' not found in source '{source.Name}'. " +
-                    $"Available members: {string.Join(", ", source.Members.Select(m => m.Name))}");
+                    $"Usable members for capability '{capabilityName}': " +
+                    $"{FormatChoices(GetUsableMemberNames(source, capabilityName))}");
+            }
+
+            if (requireCapability &&
+                !source.GetEffectiveCapabilities(pinned).ContainsKey(capabilityName))
+            {
+                throw new InvalidOperationException(
+                    $"Member '{sourceHint}' does not support capability '{capabilityName}'. " +
+                    $"Usable members in source '{source.Name}': " +
+                    $"{FormatChoices(GetUsableMemberNames(source, capabilityName))}");
             }
 
             return pinned;
@@ -279,11 +328,32 @@ internal sealed class AiCategoryRouter
                 $"Source '{source.Name}' has no members. Check configuration or discovery results.");
         }
 
-        return source.Members
+        var candidates = requireCapability
+            ? source.Members
+                .Where(member => source.GetEffectiveCapabilities(member).ContainsKey(capabilityName))
+                .ToArray()
+            : source.Members.ToArray();
+
+        if (candidates.Length == 0)
+        {
+            throw new InvalidOperationException(
+                $"Source '{source.Name}' has no member supporting capability '{capabilityName}'.");
+        }
+
+        return candidates
             .OrderBy(m => m.Order)
             .FirstOrDefault(m => m.HealthState != MemberHealthState.Unhealthy)
-            ?? source.Members.OrderBy(m => m.Order).First();
+            ?? candidates.OrderBy(m => m.Order).First();
     }
+
+    private static IReadOnlyList<string> GetUsableMemberNames(
+        AiSourceDefinition source,
+        string capabilityName)
+        => source.Members
+            .Where(member => source.GetEffectiveCapabilities(member).ContainsKey(capabilityName))
+            .OrderBy(member => member.Order)
+            .Select(member => member.Name)
+            .ToArray();
 
     private IAiAdapter ResolveAdapter(AiSourceDefinition source)
     {

--- a/src/Koan.AI/Pipeline/ChatOptionsMapper.cs
+++ b/src/Koan.AI/Pipeline/ChatOptionsMapper.cs
@@ -8,7 +8,8 @@ internal static class ChatOptionsMapper
 {
     private const string ProfileKey = "koan:ai:profile";
     private const string ThinkKey = "koan:ai:think";
-    private const string RouteAdapterKey = "koan:ai:route:adapter";
+    private const string RouteSourceKey = "koan:ai:route:source";
+    private const string LegacyRouteAdapterKey = "koan:ai:route:adapter";
     private const string RoutePolicyKey = "koan:ai:route:policy";
     private const string RouteStickyKey = "koan:ai:route:sticky";
     private const string ContextTagsKey = "koan:ai:context:tags";
@@ -142,9 +143,9 @@ internal static class ChatOptionsMapper
 
         options.AdditionalProperties ??= new AdditionalPropertiesDictionary();
 
-        if (!string.IsNullOrWhiteSpace(hints.AdapterId))
+        if (!string.IsNullOrWhiteSpace(hints.Source))
         {
-            options.AdditionalProperties[RouteAdapterKey] = hints.AdapterId;
+            options.AdditionalProperties[RouteSourceKey] = hints.Source;
         }
 
         if (!string.IsNullOrWhiteSpace(hints.Policy))
@@ -199,7 +200,7 @@ internal static class ChatOptionsMapper
             vendor = new Dictionary<string, Newtonsoft.Json.Linq.JToken>();
             foreach (var pair in options.AdditionalProperties)
             {
-                if (pair.Key is ProfileKey or ThinkKey or RouteAdapterKey or RoutePolicyKey or RouteStickyKey or ContextTagsKey or ContextGroundingKey)
+                if (pair.Key is ProfileKey or ThinkKey or RouteSourceKey or LegacyRouteAdapterKey or RoutePolicyKey or RouteStickyKey or ContextTagsKey or ContextGroundingKey)
                 {
                     continue;
                 }
@@ -243,7 +244,8 @@ internal static class ChatOptionsMapper
 
         return new AiRouteHints
         {
-            AdapterId = TryGetAdditional<string>(options, RouteAdapterKey),
+            Source = TryGetAdditional<string>(options, RouteSourceKey)
+                ?? TryGetAdditional<string>(options, LegacyRouteAdapterKey),
             Policy = TryGetAdditional<string>(options, RoutePolicyKey),
             StickyKey = TryGetAdditional<string>(options, RouteStickyKey),
         };

--- a/src/Koan.AI/README.md
+++ b/src/Koan.AI/README.md
@@ -62,6 +62,20 @@ Category configuration can constrain source or model without leaking provider me
 sources under `Koan:Ai:Sources` are the advanced routing surface; ordinary applications normally need only a provider
 reference and, when conventions cannot locate it, that provider's exact endpoint configuration.
 
+When one request must select both, the choices compose:
+
+```csharp
+var response = await Client.Conversation()
+    .WithUser("Summarize the deployment.")
+    .WithSource("local-gpu") // or "local-gpu::secondary" to pin one member
+    .WithModel("qwen3:8b")
+    .Send();
+```
+
+An explicit source or member is authoritative. Koan preserves it with the explicit model or rejects a
+missing, disabled, or capability-incompatible choice with usable alternatives; it never silently elects
+another source. Without `WithSource`, normal capability and priority election remains unchanged.
+
 Applications that operate a changing endpoint catalog can request `IAiSourceControl`. Inspect an endpoint through
 its provider protocol before applying it, then enable, disable, or remove the logical source without rebuilding the
 host:

--- a/src/Koan.AI/TECHNICAL.md
+++ b/src/Koan.AI/TECHNICAL.md
@@ -34,6 +34,11 @@ The router handles capability and category intent, optional source/model hints, 
 adapter resolution. A capability declaration means the adapter implements that operation; it does not guarantee a
 particular model is installed or healthy.
 
+`AiRouteHints.Source` carries either a source name or a pinned `source::member`; `WithSource` is its fluent
+expression. Explicit source/member and model hints are orthogonal and are preserved together. The router validates
+capability against the exact explicit choice and reports usable alternatives instead of falling back. Source-free
+requests retain automatic election. `AdapterId` and `WithRouteAdapter` remain compatibility aliases only.
+
 Background health observation updates member state without rebuilding provider topology. Startup provenance reports
 configured categories/sources, the live adapter roster, and source/member status.
 

--- a/tests/Suites/AI/Unit/Koan.Tests.AI.Unit/Specs/Conversation/AiConversationBuilder.Spec.cs
+++ b/tests/Suites/AI/Unit/Koan.Tests.AI.Unit/Specs/Conversation/AiConversationBuilder.Spec.cs
@@ -23,7 +23,7 @@ public sealed class AiConversationBuilderSpec
             .WithContextTag("tenant", "acme")
             .WithGroundingReference("doc-42")
             .WithModel("glm-1")
-            .WithRouteAdapter("ollama:test")
+            .WithSource("ollama::test")
             .WithRoutePolicy("wrw")
             .WithAugmentation("rag", configure: p => p["dataset"] = "kb")
             .WithAugmentation("moderation", enabled: false)
@@ -34,7 +34,8 @@ public sealed class AiConversationBuilderSpec
         request.Messages.Select(m => m.Role).Should().Contain(new[] { "system", "user" });
         request.Model.Should().Be("glm-1");
         request.Route.Should().NotBeNull();
-        request.Route!.AdapterId.Should().Be("ollama:test");
+        request.Route!.Source.Should().Be("ollama::test");
+        request.Route.AdapterId.Should().Be("ollama::test");
         request.Route.Policy.Should().Be("wrw");
         request.Context.Should().NotBeNull();
         request.Context!.Profile.Should().Be("support");
@@ -46,6 +47,17 @@ public sealed class AiConversationBuilderSpec
         request.Options.Should().NotBeNull();
         request.Options!.Temperature.Should().Be(0.2);
         request.Options.Profile.Should().Be("support");
+    }
+
+    [Fact]
+    public void WithRouteAdapter_remains_a_source_compatibility_alias()
+    {
+        var request = new AiConversationBuilder(new FakePipeline())
+            .WithUser("hello")
+            .WithRouteAdapter("legacy-source")
+            .Build();
+
+        request.Route!.Source.Should().Be("legacy-source");
     }
 
     [Fact]

--- a/tests/Suites/AI/Unit/Koan.Tests.AI.Unit/Specs/Routing/AiRoutingEngine.Spec.cs
+++ b/tests/Suites/AI/Unit/Koan.Tests.AI.Unit/Specs/Routing/AiRoutingEngine.Spec.cs
@@ -101,6 +101,192 @@ public sealed class AiRoutingEngineSpec
     }
 
     [Fact]
+    public void ResolveChat_with_explicit_source_and_model_preserves_both()
+    {
+        var router = CreateRouterWithSources(
+            CreateSource(
+                "alpha",
+                "alpha",
+                50,
+                new Dictionary<string, AiCapabilityConfig>
+                {
+                    ["Chat"] = new() { Model = "alpha-default" }
+                }),
+            CreateSource(
+                "beta",
+                "beta",
+                90,
+                new Dictionary<string, AiCapabilityConfig>
+                {
+                    ["Chat"] = new() { Model = "beta-default" }
+                }));
+
+        var resolution = router.ResolveChat(new AiChatRequest
+        {
+            Messages = [new("user", "hi")],
+            Model = "explicit-model",
+            Route = new AiRouteHints { Source = "alpha" }
+        });
+
+        resolution.Source.Name.Should().Be("alpha");
+        resolution.EffectiveModel.Should().Be("explicit-model");
+    }
+
+    [Fact]
+    public void ResolveChat_with_explicit_member_and_model_preserves_both()
+    {
+        var alphaMembers = new[]
+        {
+            CreateMember(
+                "alpha",
+                "primary",
+                0,
+                MemberHealthState.Healthy,
+                new Dictionary<string, AiCapabilityConfig>
+                {
+                    ["Chat"] = new() { Model = "primary-default" }
+                }),
+            CreateMember(
+                "alpha",
+                "secondary",
+                1,
+                MemberHealthState.Healthy,
+                new Dictionary<string, AiCapabilityConfig>
+                {
+                    ["Chat"] = new() { Model = "secondary-default" }
+                })
+        };
+        var router = CreateRouterWithSources(
+            CreateSource("alpha", "alpha", 50, null, alphaMembers),
+            CreateSource(
+                "beta",
+                "beta",
+                90,
+                new Dictionary<string, AiCapabilityConfig>
+                {
+                    ["Chat"] = new() { Model = "beta-default" }
+                }));
+
+        var resolution = router.ResolveChat(new AiChatRequest
+        {
+            Messages = [new("user", "hi")],
+            Model = "explicit-model",
+            Route = new AiRouteHints { Source = "alpha::secondary" }
+        });
+
+        resolution.Source.Name.Should().Be("alpha");
+        resolution.Member.Name.Should().Be("alpha::secondary");
+        resolution.EffectiveModel.Should().Be("explicit-model");
+    }
+
+    [Fact]
+    public void ResolveChat_with_missing_explicit_source_and_model_lists_usable_sources()
+    {
+        var router = CreateRouterWithSources(
+            CreateSource(
+                "alpha",
+                "alpha",
+                50,
+                new Dictionary<string, AiCapabilityConfig> { ["Chat"] = new() { Model = "alpha-default" } }),
+            CreateSource(
+                "beta",
+                "beta",
+                90,
+                new Dictionary<string, AiCapabilityConfig> { ["Chat"] = new() { Model = "beta-default" } }));
+
+        var act = () => router.ResolveChat(new AiChatRequest
+        {
+            Messages = [new("user", "hi")],
+            Model = "explicit-model",
+            Route = new AiRouteHints { Source = "missing" }
+        });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Source 'missing' not found*Usable sources for capability 'Chat': beta, alpha");
+    }
+
+    [Fact]
+    public void ResolveChat_with_disabled_explicit_source_and_model_lists_usable_sources()
+    {
+        var disabled = CreateSource(
+            "alpha",
+            "alpha",
+            100,
+            new Dictionary<string, AiCapabilityConfig> { ["Chat"] = new() { Model = "alpha-default" } }) with
+        {
+            IsEnabled = false
+        };
+        var router = CreateRouterWithSources(
+            disabled,
+            CreateSource(
+                "beta",
+                "beta",
+                90,
+                new Dictionary<string, AiCapabilityConfig> { ["Chat"] = new() { Model = "beta-default" } }));
+
+        var act = () => router.ResolveChat(new AiChatRequest
+        {
+            Messages = [new("user", "hi")],
+            Model = "explicit-model",
+            Route = new AiRouteHints { Source = "alpha" }
+        });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("AI source 'alpha' is disabled*Usable sources for capability 'Chat': beta");
+    }
+
+    [Fact]
+    public void ResolveChat_with_incompatible_explicit_source_and_model_lists_usable_sources()
+    {
+        var router = CreateRouterWithSources(
+            CreateSource(
+                "alpha",
+                "alpha",
+                100,
+                new Dictionary<string, AiCapabilityConfig> { ["Embedding"] = new() { Model = "alpha-embedding" } }),
+            CreateSource(
+                "beta",
+                "beta",
+                90,
+                new Dictionary<string, AiCapabilityConfig> { ["Chat"] = new() { Model = "beta-default" } }));
+
+        var act = () => router.ResolveChat(new AiChatRequest
+        {
+            Messages = [new("user", "hi")],
+            Model = "explicit-model",
+            Route = new AiRouteHints { Source = "alpha" }
+        });
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("Source 'alpha' does not support capability 'Chat'. Usable sources: beta");
+    }
+
+    [Fact]
+    public void ResolveChat_with_model_and_no_source_retains_priority_election()
+    {
+        var router = CreateRouterWithSources(
+            CreateSource(
+                "alpha",
+                "alpha",
+                50,
+                new Dictionary<string, AiCapabilityConfig> { ["Chat"] = new() { Model = "alpha-default" } }),
+            CreateSource(
+                "beta",
+                "beta",
+                90,
+                new Dictionary<string, AiCapabilityConfig> { ["Chat"] = new() { Model = "beta-default" } }));
+
+        var resolution = router.ResolveChat(new AiChatRequest
+        {
+            Messages = [new("user", "hi")],
+            Model = "explicit-model"
+        });
+
+        resolution.Source.Name.Should().Be("beta");
+        resolution.EffectiveModel.Should().Be("explicit-model");
+    }
+
+    [Fact]
     public void ResolveChat_skips_unhealthy_member_when_first_in_order()
     {
         var adapters = new InMemoryAdapterRegistry();
@@ -269,6 +455,19 @@ public sealed class AiRoutingEngineSpec
         };
     }
 
+    private static AiCategoryRouter CreateRouterWithSources(params AiSourceDefinition[] sources)
+    {
+        var adapters = new InMemoryAdapterRegistry();
+        var registry = new FakeSourceRegistry();
+        foreach (var source in sources)
+        {
+            adapters.Add(new TestAdapter(source.Provider));
+            registry.RegisterSource(source);
+        }
+
+        return CreateRouter(adapters, registry);
+    }
+
     private static AiMemberDefinition CreateMember(
         string source,
         string memberKey,
@@ -316,7 +515,7 @@ public sealed class AiRoutingEngineSpec
 
         public IReadOnlyCollection<AiSourceDefinition> GetSourcesWithCapability(string capabilityName)
             => _sources.Values
-                .Where(source => HasCapability(source, capabilityName))
+                .Where(source => source.IsEnabled && HasCapability(source, capabilityName))
                 .OrderByDescending(static s => s.Priority)
                 .ThenBy(static s => s.Name, StringComparer.OrdinalIgnoreCase)
                 .ToArray();


### PR DESCRIPTION
## What changed

- make explicit AI source/member selection authoritative when an explicit model is also supplied
- add canonical `AiRouteHints.Source` and `WithSource` vocabulary while retaining adapter-named compatibility aliases
- reject missing, disabled, or capability-incompatible explicit choices with usable alternatives
- preserve existing source-free election behavior
- record the guarantee in ARCH-0122 and the AI companion documentation

## Root cause

The category router handled an explicit model before its source hint. That branch elected the first eligible source and silently discarded an explicit source or member selection.

## Impact

Applications can now express “this source/member with this model” as one composable request. Invalid explicit routing intent fails correctively instead of falling back to another provider topology.

## Validation

- AI unit suite: 180/180 passed
- focused routing/builder contract: 17/17 passed
- product surface: 43 claims, 94 packages, generated outputs current
- API baselines: 77/77 configured
- public documentation truth gate: passed
- docs lint: 0 errors (repository baseline warnings only)
- skills lint: 0 errors, 0 warnings
- privacy and retired-language scan: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added explicit AI source selection, including optional member pinning.
  - Source and model choices can now be combined in the same request without silent fallback.
  - Invalid, disabled, or incompatible selections provide usable alternatives.
  - Requests without an explicit source continue using automatic capability- and priority-based selection.

- **Compatibility**
  - Existing adapter-based routing options remain supported as compatibility aliases.

- **Documentation**
  - Updated usage guidance and technical documentation for source, member, and model routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->