### PR TITLE
Restore Weaviate required Zen Garden intent

### DIFF
--- a/docs/initiatives/koan-v1/work-items/r09/R09-03-optional-contribution-lifecycle.md
+++ b/docs/initiatives/koan-v1/work-items/r09/R09-03-optional-contribution-lifecycle.md
@@ -4,12 +4,12 @@ domain: framework
 title: "R09-03 - Compile One Optional Capability Layer"
 audience: [architects, maintainers, developers, ai-agents]
 status: current
-last_updated: 2026-07-16
+last_updated: 2026-08-06
 framework_version: v0.20.0
 validation:
-  date_last_tested: 2026-07-16
+  date_last_tested: 2026-08-06
   status: passed
-  scope: generic typed contribution lifecycle, compiled service-discovery plan, and ZenGarden optional-layer proof
+  scope: generic typed contribution lifecycle, compiled service-discovery plan, ZenGarden optional-layer proof, and Weaviate required-intent regression repair
 ---
 
 # R09-03 — Compile one optional capability layer
@@ -442,3 +442,28 @@ fall back. No scaffolding or framework-maintenance concept appears in the applic
   mutation, or private downstream inspection occurred.
 - Next outcome: assess shared deterministic Data/Communication selection mechanics from their current
   typed policy owners before creating R09-04's implementation card.
+
+## 2026-08-06 Weaviate regression repair
+
+- Application intent: configuring `Koan:Data:Weaviate:ConnectionString` as
+  `zen-garden://weaviate` remains a hard choice that either resolves the requested offering or rejects
+  before connector I/O; it never becomes a native endpoint or autonomous fallback.
+- Complete expression: reference the Weaviate connector and `Sylin.Koan.ZenGarden`, call the existing
+  `AddKoan()`, and provide the deliberate connection intent. No code, decoration, context, or new
+  application concept is added.
+- Guarantee and correction: a ready matching offering produces its endpoint; an absent coordinator or
+  unresolved offering throws the established corrective error naming Weaviate, Zen Garden, and the
+  safe `auto` or native-endpoint alternatives.
+- Regression boundary: the Data adapter rebuild in `0bd5a0a90` removed Weaviate's inert
+  `Koan.ZenGarden.Contracts` dependency and required-intent branch while leaving this accepted contract
+  and its executable packaging probe intact.
+- Coalescence: restore parsing through the existing `ZenGardenConnectionIntent` contract and resolution
+  through `IServiceDiscoveryCoordinator` in `WeaviateOptionsConfigurator`; keep automatic discovery,
+  health qualification, and native endpoint precedence unchanged. Core and the Zen Garden runtime gain
+  no new owner or mechanism.
+- Ergonomics: the repair preserves the single configuration expression, adds no IntelliSense surface,
+  and keeps the three choices—native endpoint, `auto`, or required Zen Garden intent—mutually explicit.
+- Evidence result: the executable probe returned `WEAVIATE-EXPLICIT-REJECTED`; the complete packaging
+  suite passed 61/61, the host-backed Weaviate matrix passed 28/28, the Weaviate package and full
+  Release solution built with zero warnings/errors, and generated product/package truth plus public
+  documentation passed their current-state gates.

--- a/docs/reference/package-quality.json
+++ b/docs/reference/package-quality.json
@@ -714,7 +714,7 @@
       "shape": "library",
       "role": "provider",
       "status": "structurally-ready",
-      "description": "In-memory data provider for Koan: thread-safe repository for testing, development, and ephemeral storage scenarios.",
+      "description": "Host-ephemeral Koan Entity adapter with detached snapshots, exact isolation, and bounded in-process state.",
       "targetFrameworks": [
         "net10.0"
       ],
@@ -1127,7 +1127,8 @@
         "Sylin.Koan.Data.Abstractions",
         "Sylin.Koan.Data.Core",
         "Sylin.Koan.Data.Vector",
-        "Sylin.Koan.Data.Vector.Abstractions"
+        "Sylin.Koan.Data.Vector.Abstractions",
+        "Sylin.Koan.ZenGarden.Contracts"
       ],
       "readme": "src/Connectors/Data/Vector/Weaviate/README.md",
       "technicalDocumentation": "src/Connectors/Data/Vector/Weaviate/TECHNICAL.md",

--- a/docs/reference/product-surface.json
+++ b/docs/reference/product-surface.json
@@ -1920,7 +1920,8 @@
         "Sylin.Koan.Data.Abstractions",
         "Sylin.Koan.Data.Core",
         "Sylin.Koan.Data.Vector",
-        "Sylin.Koan.Data.Vector.Abstractions"
+        "Sylin.Koan.Data.Vector.Abstractions",
+        "Sylin.Koan.ZenGarden.Contracts"
       ],
       "readme": "src/Connectors/Data/Vector/Weaviate/README.md",
       "ownsReadme": true,

--- a/src/Connectors/Data/Vector/Weaviate/Koan.Data.Vector.Connector.Weaviate.csproj
+++ b/src/Connectors/Data/Vector/Weaviate/Koan.Data.Vector.Connector.Weaviate.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\..\..\Koan.Data.Vector\Koan.Data.Vector.csproj" />
     <ProjectReference Include="..\..\..\..\Koan.Data.Core\Koan.Data.Core.csproj" />
     <ProjectReference Include="..\..\..\..\Koan.Core\Koan.Core.csproj" />
+    <ProjectReference Include="..\..\..\..\Koan.ZenGarden.Contracts\Koan.ZenGarden.Contracts.csproj" />
     <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 </Project>

--- a/src/Connectors/Data/Vector/Weaviate/README.md
+++ b/src/Connectors/Data/Vector/Weaviate/README.md
@@ -39,6 +39,24 @@ The local default is `http://localhost:8080`. Configure placement or authenticat
 }
 ```
 
+To require a Weaviate offering supplied by Zen Garden, reference `Sylin.Koan.ZenGarden` and make that
+placement decision explicit:
+
+```json
+{
+  "Koan": {
+    "Data": {
+      "Weaviate": {
+        "ConnectionString": "zen-garden://weaviate"
+      }
+    }
+  }
+}
+```
+
+That intent resolves to a ready matching offering or rejects startup with corrective guidance. It never
+silently falls back to localhost. Use `"auto"` when autonomous fallback is the intended policy.
+
 Source-specific endpoint, `StorageLifecycle`, and `Access` belong under `Koan:Data:Sources:{name}` like every Koan
 adapter. The declared vector plan—not provider options—owns dimensions, metric, model, space, source, and visibility.
 

--- a/src/Connectors/Data/Vector/Weaviate/TECHNICAL.md
+++ b/src/Connectors/Data/Vector/Weaviate/TECHNICAL.md
@@ -7,6 +7,13 @@ The adapter has four runtime responsibilities:
 - `WeaviateFilter` projects neutral metadata into a constant `text[]` schema and writes exact GraphQL prefilters.
 - `WeaviateRepository` realizes the immutable `VectorSpacePlan`, point lifecycle, search, visibility, and isolation.
 
+## Placement and discovery
+
+An explicit HTTP endpoint is authoritative. `auto` uses the service-discovery coordinator and may fall back to the
+local default when no healthy candidate wins. A `zen-garden://...` connection intent is different: the options owner
+parses it through `Koan.ZenGarden.Contracts`, requests required resolution from the coordinator, and fails before
+connector I/O when no matching ready offering exists. Required intent never enters the autonomous fallback branch.
+
 ## Physical shape
 
 Every physical collection name is a readable GraphQL-safe prefix plus a SHA-256 suffix over Koan's lossless logical

--- a/src/Connectors/Data/Vector/Weaviate/WeaviateOptionsConfigurator.cs
+++ b/src/Connectors/Data/Vector/Weaviate/WeaviateOptionsConfigurator.cs
@@ -3,6 +3,7 @@ using Koan.Core.Adapters;
 using Koan.Core.Orchestration;
 using Koan.Core.Orchestration.Abstractions;
 using Koan.Data.Adapters.Configuration;
+using Koan.ZenGarden;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -29,7 +30,7 @@ internal sealed class WeaviateOptionsConfigurator : AdapterOptionsConfigurator<W
         options.Endpoint = !string.IsNullOrWhiteSpace(explicitEndpoint)
             ? explicitEndpoint
             : !string.IsNullOrWhiteSpace(legacyConnection) && !IsAutomatic(legacyConnection)
-                ? legacyConnection
+                ? ResolveConfiguredConnection(legacyConnection)
                 : Discover();
         options.ApiKey = EmptyToNull(ReadProviderConfiguration(
             options.ApiKey ?? string.Empty, Infrastructure.Constants.Configuration.Keys.ApiKey));
@@ -56,11 +57,11 @@ internal sealed class WeaviateOptionsConfigurator : AdapterOptionsConfigurator<W
             return Infrastructure.Constants.Defaults.Endpoint;
         try
         {
-            var result = _discovery.DiscoverService(Infrastructure.Constants.Provider.Name, new DiscoveryContext
-            {
-                OrchestrationMode = KoanEnv.OrchestrationMode,
-                HealthCheckTimeout = TimeSpan.FromMilliseconds(500)
-            }).GetAwaiter().GetResult();
+            var result = _discovery.DiscoverService(
+                    Infrastructure.Constants.Provider.Name,
+                    DiscoveryContext())
+                .GetAwaiter()
+                .GetResult();
             return result.IsSuccessful && !string.IsNullOrWhiteSpace(result.ServiceUrl)
                 ? result.ServiceUrl
                 : Infrastructure.Constants.Defaults.Endpoint;
@@ -71,6 +72,38 @@ internal sealed class WeaviateOptionsConfigurator : AdapterOptionsConfigurator<W
             return Infrastructure.Constants.Defaults.Endpoint;
         }
     }
+
+    private string ResolveConfiguredConnection(string connection)
+    {
+        if (!ZenGardenConnectionIntent.TryParse(connection, out var intent)) return connection;
+        if (_discovery is null)
+            throw ExplicitIntentFailure(intent!, "Koan's service-discovery coordinator is unavailable.");
+
+        var result = _discovery.ResolveServiceIntent(
+                Infrastructure.Constants.Provider.Name,
+                connection,
+                DiscoveryContext())
+            .GetAwaiter()
+            .GetResult();
+        if (!result.IsSuccessful || string.IsNullOrWhiteSpace(result.ServiceUrl))
+            throw ExplicitIntentFailure(intent!, result.ErrorMessage);
+
+        return result.ServiceUrl;
+    }
+
+    private static DiscoveryContext DiscoveryContext() => new()
+    {
+        OrchestrationMode = KoanEnv.OrchestrationMode,
+        HealthCheckTimeout = TimeSpan.FromMilliseconds(500)
+    };
+
+    private static InvalidOperationException ExplicitIntentFailure(
+        ZenGardenConnectionIntent intent,
+        string? reason) => new(
+        $"Weaviate explicit Zen Garden intent for '{intent.ToOfferingSelector()}' could not be satisfied. " +
+        $"{reason ?? "No ready Weaviate offering was found."} " +
+        "Reference and enable Koan.ZenGarden with a ready 'weaviate' offering, choose 'auto', " +
+        "or provide a native Weaviate endpoint.");
 
     private static bool IsAutomatic(string value) =>
         string.Equals(value.Trim(), Infrastructure.Constants.Configuration.Automatic, StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
## What changed

- restore Weaviate's inert dependency on `Sylin.Koan.ZenGarden.Contracts`
- parse `zen-garden://...` connection intent through the shared contract
- resolve explicit intent through `IServiceDiscoveryCoordinator.ResolveServiceIntent`
- fail closed with corrective guidance when no matching offering is ready
- preserve native endpoint precedence and autonomous `auto` fallback
- document the public configuration and update generated package/product truth

## Why

The Data adapter rebuild in `0bd5a0a90` removed Weaviate's required-intent branch and contracts dependency while leaving the accepted R09 contract and executable regression probe in place. As a result, `zen-garden://weaviate` was treated as a native endpoint instead of a hard placement promise.

## Impact

Applications using native Weaviate HTTP endpoints or `auto` are unchanged. Applications explicitly selecting Zen Garden now either receive the resolved ready offering or fail before connector I/O with actionable guidance.

## Validation

- focused required-intent packaging probe: 1/1
- complete packaging suite: 61/61
- live Docker-backed Weaviate provider matrix: 28/28
- Weaviate Release build: 0 warnings, 0 errors
- full Release solution build: 0 warnings, 0 errors
- Weaviate package creation and dependency manifest: passed
- generated product surface check: passed
- public documentation truth gate: passed
- `git diff --check`: passed