### PR TITLE
Add individual-file JSON persistence

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <!-- One evaluated dependency constitution for every release-relevant project. -->
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <!-- Historical and explicitly shelved trees preserve their frozen manifests and are not release inputs. -->
     <_KoanAtticRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)attic'))</_KoanAtticRoot>
     <_KoanShelvedRoot>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)shelved'))</_KoanShelvedRoot>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -77,6 +77,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="7.2.1" />
     <PackageVersion Include="SharpCompress" Version="0.50.0" />
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <!-- ImageSharp.Drawing 3 requires a private build license; use the newest distributable 2.x/3.x pair. -->
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />

--- a/docs/decisions/DATA-0112-json-individual-files.md
+++ b/docs/decisions/DATA-0112-json-individual-files.md
@@ -1,0 +1,127 @@
+---
+type: ADR
+domain: data
+title: "DATA-0112 - JSON individual-file persistence"
+audience: [architects, maintainers, developers, ai-agents]
+status: accepted
+last_updated: 2026-08-13
+framework_version: source-first
+validation:
+  date_last_tested: 2026-08-13
+  status: verified
+  scope: JSON adapter layout, path containment, persistence, and focused provider evidence
+---
+
+# DATA-0112 — JSON individual-file persistence
+
+## Application intent
+
+A local-first application can keep each Entity in an independently addressable JSON file so Git and other
+file-oriented workflows can select, review, commit, recover, and merge one Entity without co-committing unrelated
+Entity changes.
+
+## Public expression
+
+The existing aggregate file remains the compatibility default. An application selects independent files through the
+JSON source it already owns:
+
+```json
+{
+  "Koan": {
+    "Data": {
+      "Sources": {
+        "Default": {
+          "Adapter": "json",
+          "json": {
+            "DirectoryPath": "/workspace/src/writing",
+            "Layout": "IndividualFiles",
+            "IndividualFilePath": "{id}/article.json"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Application access remains `Entity<T>` and `EntityController<T>`. No repository registration, project reference,
+custom factory, or application file I/O is required. The complete action surface is the published
+`Sylin.Koan.Data.Connector.Json` package, ordinary `AddKoan()`, the Entity model, and the two source settings above.
+
+## Guarantee and correction
+
+`Layout = Aggregate` retains the existing one-array-file behavior. `Layout = IndividualFiles` guarantees that a
+successful single-Entity upsert or remove mutates only that Entity's owned JSON path. Each persisted file is one JSON
+object, uses the shared Entity-family and managed-field codecs, is bounded independently, and is replaced through a
+same-directory temporary file.
+
+`IndividualFilePath` is a relative template with exactly one `{id}` token and an optional `{storage}` token. Koan
+encodes token values as safe path segments, canonicalizes the result beneath `DirectoryPath`, and rejects rooted,
+escaping, ambiguous, or malformed templates before storage mutation. A persisted document whose identity does not
+map back to its own path is corrupt and fails correctively rather than becoming a different record.
+
+Individual-file scans enumerate only paths matching the Entity's rendered template and stop materialization at the
+requested candidate bound. Bulk operations are multiple independent file mutations and do not claim atomicity or the
+aggregate layout's one-replacement optimization. External filesystem writers and cross-process compare-and-swap are
+outside this layout guarantee.
+
+## Public concepts
+
+- `JsonStorageLayout.Aggregate` — preserve the existing aggregate-file storage and performance contract.
+- `JsonStorageLayout.IndividualFiles` — make one Entity equal one independently mutable JSON file.
+- `JsonDataOptions.IndividualFilePath` — express application-owned placement without teaching Koan an application's
+  article, media, or publishing schema.
+
+No framework metadata-bag type is added. Applications that preserve unknown top-level JSON members use Json.NET's
+standard `[JsonExtensionData]` dictionary; Koan's shared Entity JSON resolver already honors it and protects reserved
+framework fields.
+
+## Focused discovery and coalescence assessment
+
+- Current owner and consumers: the JSON connector owns physical layout; `IDataService`, Entity statics, controllers,
+  health, and diagnostics consume the elected repository without layout knowledge.
+- State lifetime and hot-path cost: aggregate mode keeps its host-owned immutable snapshot. Individual mode reads the
+  addressed file on demand and uses a bounded striped lock pool, avoiding one permanent cache entry per Entity.
+- Closest pattern: `Runtime/JsonRepository.cs` owns aggregate snapshots and same-directory replacement.
+- Specificity: adapter. Moving layout into Data.Core would make a backend choice framework law; moving it into Tezuri
+  would duplicate Koan serialization, managed fields, source policy, and repository semantics.
+- Disposition: keep the aggregate implementation; add the individual implementation; absorb shared path/codec
+  mechanics only where lifecycle and meaning are identical; delete no compatibility path.
+- Target owner: `Sylin.Koan.Data.Connector.Json`. A wider owner has no file-layout meaning; a narrower application
+  owner cannot preserve provider guarantees without recreating the adapter.
+
+## Ergonomics
+
+The configuration reads as the business decision: aggregate persistence or individual files. IntelliSense presents
+two semantic choices without the brittle `AggregateFile`/`RecordFiles` vocabulary. The optional path template is
+visible only when placement matters; its defaults produce `{storage}/{id}.json`. The normal Entity and controller
+coding models do not branch.
+
+## Implementation placement
+
+| New code | Location | Justification |
+|---|---|---|
+| `JsonStorageLayout` | `src/Connectors/Data/Json/JsonStorageLayout.cs` | Public adapter option with one top-level type per file. |
+| New option members | `src/Connectors/Data/Json/JsonDataOptions.cs` | The existing typed configuration owner. |
+| Individual path compiler | `src/Connectors/Data/Json/Runtime/JsonIndividualFileLocator.cs` | Adapter-internal rendering, matching, encoding, and containment. |
+| Individual repository | `src/Connectors/Data/Json/Runtime/JsonIndividualFilesRepository.cs` | The KeyValue backend primitives for the new physical layout. |
+| Bounded lock/claim registry | `src/Connectors/Data/Json/Runtime/JsonIndividualFileRegistry.cs` | Host-owned coordination without record-count-proportional retained state. |
+| Focused proof | `tests/Suites/Data/Connector.Json/.../JsonIndividualFilesSpec.cs` | Real-host provider evidence for placement, CRUD, external edits, partitions, and failures. |
+
+## Constraints and exclusions
+
+- No HTTP route or controller change.
+- No new Data.Core persistence vocabulary.
+- No automatic migration between layouts.
+- No provider-bounded Entity streaming claim; JSON continues to reject `AllStream` and `QueryStream`.
+- No atomic multi-file batch claim.
+- No ETag, version-token, or cross-process concurrency claim in this slice.
+- Stable strings and tunables remain in connector constants/options.
+- README and TECHNICAL remain the current instruction and exact-contract owners.
+
+## Release plan
+
+The change is an additive patch in the connector's existing `0.21` compatibility line. Publication occurs only from
+the repository's certified `main` workflow. The release must include the new
+`Sylin.Koan.Data.Connector.Json` identity and an updated coherent `Sylin.Koan`/`Sylin.Koan.App` bundle before an
+external consumer is told to pin it.

--- a/docs/decisions/toc.yml
+++ b/docs/decisions/toc.yml
@@ -304,6 +304,8 @@
       href: DATA-0110-compact-data-adapter-language.md
     - name: DATA-0111 Verified runtime default Data cutover
       href: DATA-0111-verified-default-data-cutover.md
+    - name: DATA-0112 JSON individual-file persistence
+      href: DATA-0112-json-individual-files.md
 - name: Web (WEB)
   items:
     - name: WEB-0010 Separate AI web surface

--- a/src/Connectors/Data/Cockroach/Koan.Data.Connector.Cockroach.csproj
+++ b/src/Connectors/Data/Cockroach/Koan.Data.Connector.Cockroach.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>Koan.Data.Connector.Cockroach</AssemblyName>

--- a/src/Connectors/Data/Couchbase/Koan.Data.Connector.Couchbase.csproj
+++ b/src/Connectors/Data/Couchbase/Koan.Data.Connector.Couchbase.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Description>Couchbase provider for Koan Data with direct KV, SQL++, CAS, compact mappings, and neutral source integration.</Description>

--- a/src/Connectors/Data/ElasticSearch/Koan.Data.Connector.ElasticSearch.csproj
+++ b/src/Connectors/Data/ElasticSearch/Koan.Data.Connector.ElasticSearch.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Connectors/Data/Json/Infrastructure/Constants.cs
+++ b/src/Connectors/Data/Json/Infrastructure/Constants.cs
@@ -10,6 +10,7 @@ internal static class Constants
         internal const int Priority = 0;
         internal const int MaximumFilesPerHost = 1024;
         internal const long MaximumFileBytes = 64L * 1024 * 1024;
+        internal const int IndividualFileLockStripes = 64;
     }
 
     internal static class Configuration
@@ -17,16 +18,23 @@ internal static class Constants
         internal const string Section = "Koan:Data:Json";
         internal const string DefaultSourceSection = "Koan:Data:Sources:Default:json";
         internal const string DirectoryPath = nameof(JsonDataOptions.DirectoryPath);
+        internal const string Layout = nameof(JsonDataOptions.Layout);
+        internal const string IndividualFilePath = nameof(JsonDataOptions.IndividualFilePath);
     }
 
     internal static class Storage
     {
         internal const string Extension = ".json";
         internal const char PartitionSeparator = '#';
+        internal const string IdToken = "{id}";
+        internal const string StorageToken = "{storage}";
+        internal const string DefaultIndividualFilePath = "{storage}/{id}.json";
     }
 
     internal static class Bootstrap
     {
         internal const string DirectoryPath = "data.json.directory";
+        internal const string Layout = "data.json.layout";
+        internal const string IndividualFilePath = "data.json.individualFilePath";
     }
 }

--- a/src/Connectors/Data/Json/Initialization/JsonModule.cs
+++ b/src/Connectors/Data/Json/Initialization/JsonModule.cs
@@ -16,6 +16,7 @@ public sealed class JsonModule : KoanModule
     {
         services.AddKoanOptions<JsonDataOptions>(Infrastructure.Constants.Configuration.Section);
         services.TryAddSingleton<JsonFileRegistry>();
+        services.TryAddSingleton<JsonIndividualFileRegistry>();
         services.AddSingleton<IDataAdapterFactory, JsonAdapterFactory>();
         services.TryAddEnumerable(ServiceDescriptor.Singleton<IHealthContributor, JsonHealthContributor>());
     }
@@ -38,5 +39,27 @@ public sealed class JsonModule : KoanModule
             source: directory.Source,
             consumers: ["Koan.Data.Connector.Json.Runtime.JsonRoute"],
             sourceKey: directory.ResolvedKey);
+        var layout = Configuration.ReadFirstWithSource(
+            configuration,
+            new JsonDataOptions().Layout.ToString(),
+            $"{Infrastructure.Constants.Configuration.Section}:{Infrastructure.Constants.Configuration.Layout}",
+            $"{Infrastructure.Constants.Configuration.DefaultSourceSection}:{Infrastructure.Constants.Configuration.Layout}");
+        module.AddSetting(
+            Infrastructure.Constants.Bootstrap.Layout,
+            layout.Value,
+            source: layout.Source,
+            consumers: ["Koan.Data.Connector.Json.Runtime.JsonRoute"],
+            sourceKey: layout.ResolvedKey);
+        var individualFilePath = Configuration.ReadFirstWithSource(
+            configuration,
+            new JsonDataOptions().IndividualFilePath,
+            $"{Infrastructure.Constants.Configuration.Section}:{Infrastructure.Constants.Configuration.IndividualFilePath}",
+            $"{Infrastructure.Constants.Configuration.DefaultSourceSection}:{Infrastructure.Constants.Configuration.IndividualFilePath}");
+        module.AddSetting(
+            Infrastructure.Constants.Bootstrap.IndividualFilePath,
+            individualFilePath.Value,
+            source: individualFilePath.Source,
+            consumers: ["Koan.Data.Connector.Json.Runtime.JsonRoute"],
+            sourceKey: individualFilePath.ResolvedKey);
     }
 }

--- a/src/Connectors/Data/Json/JsonAdapterFactory.cs
+++ b/src/Connectors/Data/Json/JsonAdapterFactory.cs
@@ -42,12 +42,23 @@ public sealed class JsonAdapterFactory : IDataAdapterFactory
             this,
             resolvedSource);
 
-        return new JsonRepository<TEntity, TKey>(
-            route,
-            services.GetRequiredService<JsonFileRegistry>(),
-            services.GetRequiredService<Koan.Data.Core.Semantics.DataSegmentationPlan>(),
-            this,
-            services);
+        return route.Layout switch
+        {
+            JsonStorageLayout.Aggregate => new JsonRepository<TEntity, TKey>(
+                route,
+                services.GetRequiredService<JsonFileRegistry>(),
+                services.GetRequiredService<Koan.Data.Core.Semantics.DataSegmentationPlan>(),
+                this,
+                services),
+            JsonStorageLayout.IndividualFiles => new JsonIndividualFilesRepository<TEntity, TKey>(
+                route,
+                services.GetRequiredService<JsonIndividualFileRegistry>(),
+                services.GetRequiredService<Koan.Data.Core.Semantics.DataSegmentationPlan>(),
+                this,
+                services),
+            _ => throw new InvalidOperationException(
+                $"JSON layout '{route.Layout}' is not supported for source '{resolvedSource}'.")
+        };
     }
 
     public StorageNamingCapability GetNamingCapability(IServiceProvider services) => new()

--- a/src/Connectors/Data/Json/JsonDataOptions.cs
+++ b/src/Connectors/Data/Json/JsonDataOptions.cs
@@ -2,9 +2,19 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Koan.Data.Connector.Json;
 
-/// <summary>The one JSON adapter choice: where this source keeps its entity files.</summary>
+/// <summary>Physical placement choices for a JSON data source.</summary>
 public sealed class JsonDataOptions
 {
     [Required]
     public string DirectoryPath { get; set; } = "data";
+
+    /// <summary>How the source groups persisted Entities.</summary>
+    public JsonStorageLayout Layout { get; set; } = JsonStorageLayout.Aggregate;
+
+    /// <summary>
+    /// Relative path template used by <see cref="JsonStorageLayout.IndividualFiles"/>. The template must contain one
+    /// <c>{id}</c> token and may contain one <c>{storage}</c> token.
+    /// </summary>
+    [Required]
+    public string IndividualFilePath { get; set; } = Infrastructure.Constants.Storage.DefaultIndividualFilePath;
 }

--- a/src/Connectors/Data/Json/JsonStorageLayout.cs
+++ b/src/Connectors/Data/Json/JsonStorageLayout.cs
@@ -1,0 +1,11 @@
+namespace Koan.Data.Connector.Json;
+
+/// <summary>Controls whether a JSON source groups an Entity set or persists each Entity independently.</summary>
+public enum JsonStorageLayout
+{
+    /// <summary>Persist the Entity set as one JSON array file.</summary>
+    Aggregate,
+
+    /// <summary>Persist each Entity as its own JSON object file.</summary>
+    IndividualFiles
+}

--- a/src/Connectors/Data/Json/Koan.Data.Connector.Json.csproj
+++ b/src/Connectors/Data/Json/Koan.Data.Connector.Json.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Zero-configuration JSON persistence for small Koan applications, tests, and local development.</Description>

--- a/src/Connectors/Data/Json/README.md
+++ b/src/Connectors/Data/Json/README.md
@@ -36,31 +36,62 @@ The managed default directory is `data`. Choose another root only when placement
 
 Named sources use the standard source grammar and may choose their own `json:DirectoryPath`.
 
+By default, each Entity set remains one aggregate JSON array. Choose independent JSON object files when the file is
+itself part of an application workflow such as Git review or selective publication:
+
+```json
+{
+  "Koan": {
+    "Data": {
+      "Sources": {
+        "Default": {
+          "Adapter": "json",
+          "json": {
+            "DirectoryPath": "/workspace/src/writing",
+            "Layout": "IndividualFiles",
+            "IndividualFilePath": "{id}/article.json"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+`IndividualFilePath` defaults to `{storage}/{id}.json`. It must be a relative `.json` path containing exactly one
+`{id}` token; `{storage}` is optional for a dedicated, unpartitioned source and required when one source must isolate
+multiple Entity roots or partitions. Token values are encoded as safe path segments.
+
 ## What succeeds
 
-- Managed/read-write use creates the directory and Entity file on the first write.
+- Managed/read-write use creates the required directories and Entity file on the first write.
 - Every read returns a detached Entity. Editing it changes nothing until `Save()` succeeds.
-- A write builds a complete candidate file, replaces the target, then publishes the new live snapshot.
-- Bulk upsert and delete each perform one physical file replacement.
+- Aggregate writes build a complete candidate file, replace the target, then publish the new live snapshot.
+- Aggregate bulk upsert and delete each perform one physical file replacement.
+- Individual writes replace only the addressed Entity file and observe external file edits on the next read.
+- Individual delete removes only the Entity file; it never removes its containing directory or sibling application files.
 - A new Koan host restores root/variant identity and managed isolation fields from disk.
-- Two source path spellings that resolve to the same canonical file share one in-process snapshot and write gate.
+- In Aggregate layout, two source path spellings that resolve to the same canonical file share one in-process
+  snapshot and write gate. IndividualFiles uses a bounded host-wide gate pool and retains no per-record snapshot.
 
 ## Boundaries and failures
 
-- Corrupt JSON, duplicate identities, incompatible Entity roots, and files larger than 64 MiB never become an empty
-  successful store.
+- Corrupt JSON, duplicate identities, incompatible Entity roots, identity/path mismatches, unsafe path templates, and
+  files larger than 64 MiB never become an empty successful store.
 - Read-only writes fail before filesystem mutation.
-- `External` requires an existing directory and Entity file; Koan never provisions either.
-- Physical `Map<T>` declarations reject because the connector owns one Entity-array file shape.
+- `External` requires an existing directory and never provisions directories or Entity files.
+- Physical `Map<T>` declarations reject because the connector owns its JSON file shapes.
 - Required atomic batches and provider-bounded Entity streams reject before partial work.
-- The 1,025th canonical Entity/partition file in one host rejects; the fixed 1,024-file ceiling keeps host state finite.
+- In Aggregate layout, the 1,025th canonical Entity/partition file in one host rejects; the fixed 1,024-file ceiling
+  keeps aggregate snapshots finite. IndividualFiles retains no record-count-proportional registry.
 
 ## Choose a database connector when
 
-You need multi-process writers, transactions, indexes, provider-side queries, crash-recovery guarantees, files above
-64 MiB, or dynamically unbounded partitions. JSON is a deliberately small local persistence floor. It does not watch
-for external edits after a file enters the host cache, and lexical path canonicalization does not promise to collapse
-every symlink alias.
+You need multi-process writers, transactions, indexes, provider-side queries, crash-recovery guarantees, individual
+records above 64 MiB, or dynamically unbounded partitions. JSON is a deliberately small local persistence floor.
+Aggregate layout does not watch for external edits after a file enters the host cache; IndividualFiles reads the
+addressed document from disk but does not provide cross-process compare-and-swap. Lexical path canonicalization does
+not promise to collapse every symlink alias.
 
 Use `FirstPage`/`Page` to limit results returned to application code. `AllStream` and `QueryStream` remain unavailable
 because loading a whole file before yielding would not be provider-bounded streaming.

--- a/src/Connectors/Data/Json/Runtime/JsonFeatures.cs
+++ b/src/Connectors/Data/Json/Runtime/JsonFeatures.cs
@@ -30,4 +30,9 @@ internal static class JsonFeatures
         .Add(
             DataCaps.Query.FilterExecution,
             new FilterExecutionProfile(FilterExecutionKind.Scan, SupportsBoundedCandidates: true));
+
+    internal static void DescribeIndividualFilesBackend(ICapabilities capabilities) => capabilities
+        .Add(
+            DataCaps.Query.FilterExecution,
+            new FilterExecutionProfile(FilterExecutionKind.Scan, SupportsBoundedCandidates: true));
 }

--- a/src/Connectors/Data/Json/Runtime/JsonIndividualFileLocator.cs
+++ b/src/Connectors/Data/Json/Runtime/JsonIndividualFileLocator.cs
@@ -1,0 +1,215 @@
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+
+namespace Koan.Data.Connector.Json.Runtime;
+
+/// <summary>Compiles one safe individual-file path template for one physical Entity storage name.</summary>
+internal sealed class JsonIndividualFileLocator
+{
+    private static readonly StringComparison PathComparison = OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    private readonly string _root;
+    private readonly string _prefix;
+    private readonly string _suffix;
+    private readonly string _searchRoot;
+    private readonly string _searchPattern;
+    private readonly SearchOption _searchOption;
+
+    internal JsonIndividualFileLocator(string directoryPath, string template, string storageName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(directoryPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(template);
+        ArgumentException.ThrowIfNullOrWhiteSpace(storageName);
+
+        _root = Path.GetFullPath(directoryPath);
+        var normalized = NormalizeAndValidate(template);
+        UsesStorageToken = normalized.Contains(Infrastructure.Constants.Storage.StorageToken, StringComparison.Ordinal);
+
+        var rendered = normalized.Replace(
+            Infrastructure.Constants.Storage.StorageToken,
+            EncodeToken(storageName),
+            StringComparison.Ordinal);
+        var idIndex = rendered.IndexOf(Infrastructure.Constants.Storage.IdToken, StringComparison.Ordinal);
+        _prefix = rendered[..idIndex];
+        _suffix = rendered[(idIndex + Infrastructure.Constants.Storage.IdToken.Length)..];
+
+        var slashBeforeId = rendered.LastIndexOf('/', idIndex);
+        var searchRootRelative = slashBeforeId < 0 ? "" : rendered[..slashBeforeId];
+        _searchRoot = ContainedPath(searchRootRelative);
+
+        var fileSegment = rendered[(rendered.LastIndexOf('/') + 1)..];
+        _searchPattern = fileSegment.Replace(
+            Infrastructure.Constants.Storage.IdToken,
+            "*",
+            StringComparison.Ordinal);
+        _searchOption = rendered.IndexOf('/', idIndex + Infrastructure.Constants.Storage.IdToken.Length) >= 0
+            ? SearchOption.AllDirectories
+            : SearchOption.TopDirectoryOnly;
+    }
+
+    internal bool UsesStorageToken { get; }
+
+    internal string PathFor<TKey>(TKey id) where TKey : notnull
+    {
+        var encoded = EncodeToken(KeyText(id));
+        if (encoded.Length == 0)
+            throw new InvalidOperationException("JSON individual-file identity cannot render as an empty path token.");
+        return ContainedPath(_prefix + encoded + _suffix);
+    }
+
+    internal IEnumerable<string> EnumeratePaths()
+    {
+        if (!Directory.Exists(_searchRoot)) yield break;
+
+        foreach (var path in Directory.EnumerateFiles(_searchRoot, _searchPattern, _searchOption))
+        {
+            var full = Path.GetFullPath(path);
+            var relative = Path.GetRelativePath(_root, full).Replace(Path.DirectorySeparatorChar, '/');
+            if (Path.AltDirectorySeparatorChar != Path.DirectorySeparatorChar)
+                relative = relative.Replace(Path.AltDirectorySeparatorChar, '/');
+            if (Matches(relative)) yield return full;
+        }
+    }
+
+    private bool Matches(string relative)
+    {
+        if (!relative.StartsWith(_prefix, PathComparison) || !relative.EndsWith(_suffix, PathComparison))
+            return false;
+
+        var tokenLength = relative.Length - _prefix.Length - _suffix.Length;
+        if (tokenLength <= 0) return false;
+        var token = relative.AsSpan(_prefix.Length, tokenLength);
+        return token.IndexOf('/') < 0 && token.IndexOf('\\') < 0;
+    }
+
+    private string ContainedPath(string relative)
+    {
+        ValidateRenderedRelative(relative);
+        var platformRelative = relative.Replace('/', Path.DirectorySeparatorChar);
+        var full = Path.GetFullPath(Path.Combine(_root, platformRelative));
+        var rootWithSeparator = _root.EndsWith(Path.DirectorySeparatorChar)
+            ? _root
+            : _root + Path.DirectorySeparatorChar;
+        if (!string.Equals(full, _root, PathComparison) && !full.StartsWith(rootWithSeparator, PathComparison))
+        {
+            throw new InvalidOperationException(
+                $"JSON individual-file path '{relative}' resolves outside source directory '{_root}'.");
+        }
+        return full;
+    }
+
+    private static void ValidateRenderedRelative(string relative)
+    {
+        if (relative.Length == 0) return;
+
+        foreach (var segment in relative.Split('/'))
+        {
+            if (segment.Length == 0 || segment.EndsWith(' ') || segment.EndsWith('.') ||
+                segment.Any(static character => character < ' ' || "<>:\"|?*".Contains(character)) ||
+                IsWindowsDeviceName(segment))
+            {
+                throw new InvalidOperationException(
+                    $"JSON individual-file path '{relative}' contains a platform-unsafe path segment '{segment}'.");
+            }
+        }
+    }
+
+    private static string NormalizeAndValidate(string template)
+    {
+        if (Path.IsPathRooted(template))
+            throw InvalidTemplate(template, "it must be relative to DirectoryPath");
+
+        var normalized = template.Replace('\\', '/').Trim();
+        if (normalized.Length == 0 || normalized[0] == '/')
+            throw InvalidTemplate(template, "it must be a non-empty relative path");
+        if (!normalized.EndsWith(Infrastructure.Constants.Storage.Extension, StringComparison.OrdinalIgnoreCase))
+            throw InvalidTemplate(template, $"it must end with '{Infrastructure.Constants.Storage.Extension}'");
+
+        var idCount = Count(normalized, Infrastructure.Constants.Storage.IdToken);
+        if (idCount != 1)
+            throw InvalidTemplate(template, $"it must contain exactly one '{Infrastructure.Constants.Storage.IdToken}' token");
+        if (Count(normalized, Infrastructure.Constants.Storage.StorageToken) > 1)
+            throw InvalidTemplate(template, $"it may contain at most one '{Infrastructure.Constants.Storage.StorageToken}' token");
+
+        var withoutKnownTokens = normalized
+            .Replace(Infrastructure.Constants.Storage.IdToken, "", StringComparison.Ordinal)
+            .Replace(Infrastructure.Constants.Storage.StorageToken, "", StringComparison.Ordinal);
+        if (withoutKnownTokens.Contains('{') || withoutKnownTokens.Contains('}'))
+            throw InvalidTemplate(template, "it contains an unknown or malformed token");
+
+        foreach (var segment in normalized.Split('/'))
+        {
+            if (segment.Length == 0 || segment is "." or "..")
+                throw InvalidTemplate(template, "it contains an empty or traversing path segment");
+        }
+
+        return normalized;
+    }
+
+    private static int Count(string value, string token)
+    {
+        var count = 0;
+        var offset = 0;
+        while ((offset = value.IndexOf(token, offset, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            offset += token.Length;
+        }
+        return count;
+    }
+
+    private static string KeyText<TKey>(TKey id) where TKey : notnull
+    {
+        if (id is string text) return text;
+        if (id is Guid guid) return guid.ToString("D");
+        if (id is IFormattable formattable) return formattable.ToString(null, CultureInfo.InvariantCulture) ?? "";
+
+        var converter = TypeDescriptor.GetConverter(typeof(TKey));
+        return converter.CanConvertTo(typeof(string))
+            ? converter.ConvertToInvariantString(id) ?? ""
+            : id.ToString() ?? "";
+    }
+
+    private static string EncodeToken(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        var encoded = new StringBuilder(bytes.Length);
+        foreach (var valueByte in bytes)
+        {
+            if (valueByte is >= (byte)'a' and <= (byte)'z' or >= (byte)'0' and <= (byte)'9' or (byte)'-' or (byte)'_')
+            {
+                encoded.Append((char)valueByte);
+            }
+            else
+            {
+                encoded.Append('%').Append(valueByte.ToString("X2", CultureInfo.InvariantCulture));
+            }
+        }
+        var result = encoded.ToString();
+        if (!IsWindowsDeviceName(result)) return result;
+
+        // Device names are reserved even with an extension on Windows. Encoding the first byte keeps the mapping
+        // stable across platforms while preserving a one-to-one identity token.
+        return $"%{(byte)result[0]:X2}{result[1..]}";
+    }
+
+    private static bool IsWindowsDeviceName(string segment)
+    {
+        var stem = segment.Split('.', 2)[0].TrimEnd(' ', '.');
+        return stem.Equals("CON", StringComparison.OrdinalIgnoreCase) ||
+               stem.Equals("PRN", StringComparison.OrdinalIgnoreCase) ||
+               stem.Equals("AUX", StringComparison.OrdinalIgnoreCase) ||
+               stem.Equals("NUL", StringComparison.OrdinalIgnoreCase) ||
+               stem.Equals("CLOCK$", StringComparison.OrdinalIgnoreCase) ||
+               (stem.Length == 4 && stem.StartsWith("COM", StringComparison.OrdinalIgnoreCase) && stem[3] is >= '1' and <= '9') ||
+               (stem.Length == 4 && stem.StartsWith("LPT", StringComparison.OrdinalIgnoreCase) && stem[3] is >= '1' and <= '9');
+    }
+
+    private static InvalidOperationException InvalidTemplate(string template, string reason) => new(
+        $"JSON IndividualFilePath '{template}' is invalid: {reason}. Use a relative JSON path with one " +
+        $"'{Infrastructure.Constants.Storage.IdToken}' token and, when storage isolation is required, one " +
+        $"'{Infrastructure.Constants.Storage.StorageToken}' token.");
+}

--- a/src/Connectors/Data/Json/Runtime/JsonIndividualFileRegistry.cs
+++ b/src/Connectors/Data/Json/Runtime/JsonIndividualFileRegistry.cs
@@ -1,0 +1,38 @@
+using System.Collections.Concurrent;
+
+namespace Koan.Data.Connector.Json.Runtime;
+
+/// <summary>
+/// Coordinates individual-file mutations with fixed host memory and protects storage-independent templates from
+/// being claimed by incompatible Entity roots.
+/// </summary>
+internal sealed class JsonIndividualFileRegistry
+{
+    private readonly SemaphoreSlim[] _gates = Enumerable.Range(
+            0,
+            Infrastructure.Constants.Provider.IndividualFileLockStripes)
+        .Select(static _ => new SemaphoreSlim(1, 1))
+        .ToArray();
+    private readonly ConcurrentDictionary<string, LayoutOwner> _unqualifiedLayouts = new(JsonFileRegistry.PathComparer);
+
+    internal SemaphoreSlim Gate(string canonicalPath)
+    {
+        var hash = unchecked((uint)JsonFileRegistry.PathComparer.GetHashCode(canonicalPath));
+        return _gates[hash % (uint)_gates.Length];
+    }
+
+    internal void ClaimUnqualifiedLayout(string directoryPath, string template, Type rootType, Type keyType)
+    {
+        var key = Path.GetFullPath(directoryPath) + "\0" + template;
+        var requested = new LayoutOwner(rootType, keyType);
+        var owner = _unqualifiedLayouts.GetOrAdd(key, requested);
+        if (owner == requested) return;
+
+        throw new InvalidOperationException(
+            $"JSON IndividualFilePath '{template}' under '{directoryPath}' omits '{{storage}}' and is already owned " +
+            $"by Entity root '{owner.RootType.FullName}' with key '{owner.KeyType.FullName}', not " +
+            $"'{rootType.FullName}'/'{keyType.FullName}'. Use a dedicated source or include '{{storage}}' in the path.");
+    }
+
+    private sealed record LayoutOwner(Type RootType, Type KeyType);
+}

--- a/src/Connectors/Data/Json/Runtime/JsonIndividualFilesRepository.cs
+++ b/src/Connectors/Data/Json/Runtime/JsonIndividualFilesRepository.cs
@@ -1,0 +1,383 @@
+using System.Text;
+using Koan.Core.Capabilities;
+using Koan.Data.Abstractions;
+using Koan.Data.Abstractions.Instructions;
+using Koan.Data.Abstractions.Naming;
+using Koan.Data.Abstractions.Sources;
+using Koan.Data.Core;
+using Koan.Data.Core.KeyValue;
+using Koan.Data.Core.Polymorphism;
+using Koan.Data.Core.Semantics;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+
+namespace Koan.Data.Connector.Json.Runtime;
+
+/// <summary>Translates the KeyValue family primitives to independently replaceable JSON object files.</summary>
+internal sealed class JsonIndividualFilesRepository<TEntity, TKey> : KeyValueStore<TEntity, TKey>
+    where TEntity : class, IEntity<TKey>
+    where TKey : notnull
+{
+    private static readonly Type RootType = EntityRootDescriptor.For(typeof(TEntity)).RootType;
+    private static readonly JsonSerializerSettings Settings = EntityJsonSerialization.Apply(new JsonSerializerSettings
+    {
+        ContractResolver = new CamelCasePropertyNamesContractResolver(),
+        Formatting = Formatting.None,
+        NullValueHandling = NullValueHandling.Include
+    });
+    private static readonly Encoding Utf8 = new UTF8Encoding(false);
+
+    private readonly JsonRoute _route;
+    private readonly JsonIndividualFileRegistry _files;
+    private readonly IReadOnlyList<DataSegmentationField> _segmentation;
+    private readonly INamingProvider _naming;
+    private readonly IServiceProvider _services;
+
+    internal JsonIndividualFilesRepository(
+        JsonRoute route,
+        JsonIndividualFileRegistry files,
+        DataSegmentationPlan segmentation,
+        INamingProvider naming,
+        IServiceProvider services)
+    {
+        _route = route;
+        _files = files;
+        _segmentation = segmentation.For(RootType).Fields;
+        _naming = naming;
+        _services = services;
+
+        var baseStorage = _naming.ResolveStorage(RootType, partition: null, _services);
+        var locator = new JsonIndividualFileLocator(_route.DirectoryPath, _route.IndividualFilePath, baseStorage);
+        if (!locator.UsesStorageToken)
+        {
+            _files.ClaimUnqualifiedLayout(
+                _route.DirectoryPath,
+                _route.IndividualFilePath,
+                RootType,
+                typeof(TKey));
+        }
+    }
+
+    protected override async Task<KvRecord<TEntity>?> ReadAsync(TKey id, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        DemandReadableRoot();
+        var locator = CurrentLocator();
+        var path = locator.PathFor(id);
+        var gate = _files.Gate(path);
+        await gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            return await ReadRecord(locator, path, id, validateExpectedId: true, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    protected override Task<IReadOnlyList<KvRecord<TEntity>>> ScanAsync(CancellationToken ct) =>
+        ScanCore(int.MaxValue, ct);
+
+    protected override Task<IReadOnlyList<KvRecord<TEntity>>> ScanBoundedAsync(
+        int maxCandidates,
+        CancellationToken ct)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxCandidates);
+        return ScanCore(maxCandidates, ct);
+    }
+
+    protected override async Task WriteAsync(TKey id, KvRecord<TEntity> record, CancellationToken ct)
+    {
+        _route.Policy.Demand(DataOperationEffect.Write, "persist an individual JSON entity file");
+        ct.ThrowIfCancellationRequested();
+        var payload = Encode(record);
+        DemandPayloadBound(payload, "write");
+
+        var locator = CurrentLocator();
+        var path = locator.PathFor(id);
+        var gate = _files.Gate(path);
+        await gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_route.Policy.StorageLifecycle == StorageLifecycle.External && !File.Exists(path))
+            {
+                throw new FileNotFoundException(
+                    $"External JSON entity file '{path}' does not exist; Koan will not create it.",
+                    path);
+            }
+
+            await Persist(path, payload, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    protected override async Task<bool> RemoveAsync(TKey id, CancellationToken ct)
+    {
+        _route.Policy.Demand(DataOperationEffect.Write, "remove an individual JSON entity file");
+        ct.ThrowIfCancellationRequested();
+        DemandReadableRoot();
+        var locator = CurrentLocator();
+        var path = locator.PathFor(id);
+        var gate = _files.Gate(path);
+        await gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_route.Policy.StorageLifecycle == StorageLifecycle.External && !File.Exists(path))
+            {
+                throw new FileNotFoundException(
+                    $"External JSON entity file '{path}' does not exist; Koan will not create it.",
+                    path);
+            }
+            if (!File.Exists(path)) return false;
+            File.Delete(path);
+            return true;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    protected override async Task<int> ClearAsync(CancellationToken ct)
+    {
+        _route.Policy.Demand(DataOperationEffect.Write, "clear individual JSON entity files");
+        ct.ThrowIfCancellationRequested();
+        DemandReadableRoot();
+        var locator = CurrentLocator();
+        var paths = locator.EnumeratePaths().ToArray();
+
+        // Validate every owned document before the first deletion. Corrupt storage is never converted into an empty
+        // successful store, even for an explicit clear.
+        foreach (var path in paths)
+        {
+            ct.ThrowIfCancellationRequested();
+            var gate = _files.Gate(path);
+            await gate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                _ = await ReadRecord(locator, path, expectedId: default!, validateExpectedId: false, ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+
+        var removed = 0;
+        foreach (var path in paths)
+        {
+            ct.ThrowIfCancellationRequested();
+            var gate = _files.Gate(path);
+            await gate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                if (!File.Exists(path)) continue;
+                File.Delete(path);
+                removed++;
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+        return removed;
+    }
+
+    protected override void DescribeBackend(ICapabilities capabilities) =>
+        JsonFeatures.DescribeIndividualFilesBackend(capabilities);
+
+    public override async Task<TResult> ExecuteAsync<TResult>(Instruction instruction, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(instruction);
+        ct.ThrowIfCancellationRequested();
+        if (instruction.Name != DataInstructions.EnsureCreated)
+            return await base.ExecuteAsync<TResult>(instruction, ct).ConfigureAwait(false);
+
+        if (_route.Policy.StorageLifecycle != StorageLifecycle.Managed ||
+            _route.Policy.Access != DataSourceAccess.ReadWrite)
+        {
+            DemandReadableRoot();
+            return (TResult)(object)true;
+        }
+
+        _route.Policy.Demand(DataOperationEffect.SchemaOrAdmin, "ensure individual JSON entity storage");
+        Directory.CreateDirectory(_route.DirectoryPath);
+        return (TResult)(object)true;
+    }
+
+    private async Task<IReadOnlyList<KvRecord<TEntity>>> ScanCore(int maximum, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        DemandReadableRoot();
+        var locator = CurrentLocator();
+        var result = new List<KvRecord<TEntity>>();
+        var identities = new HashSet<TKey>();
+
+        foreach (var path in locator.EnumeratePaths())
+        {
+            ct.ThrowIfCancellationRequested();
+            if (result.Count == maximum) break;
+
+            var gate = _files.Gate(path);
+            await gate.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                var record = await ReadRecord(
+                    locator,
+                    path,
+                    expectedId: default!,
+                    validateExpectedId: false,
+                    ct).ConfigureAwait(false);
+                if (record is null) continue;
+                if (!identities.Add(record.Value.Entity.Id))
+                {
+                    throw new InvalidDataException(
+                        $"JSON individual-file source '{_route.Source}' contains duplicate identity " +
+                        $"'{record.Value.Entity.Id}'. Repair the duplicate deliberately; ambiguous storage is never accepted.");
+                }
+                result.Add(record.Value);
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+        return result;
+    }
+
+    private async Task<KvRecord<TEntity>?> ReadRecord(
+        JsonIndividualFileLocator locator,
+        string path,
+        TKey expectedId,
+        bool validateExpectedId,
+        CancellationToken ct)
+    {
+        if (!File.Exists(path)) return null;
+
+        var length = new FileInfo(path).Length;
+        if (length > Infrastructure.Constants.Provider.MaximumFileBytes)
+        {
+            throw new InvalidDataException(
+                $"Koan JSON entity file '{path}' is {length} bytes and exceeds the 64 MiB safety bound. " +
+                "Reduce the record or use a database adapter before reading it.");
+        }
+
+        try
+        {
+            var json = await File.ReadAllTextAsync(path, Utf8, ct).ConfigureAwait(false);
+            var document = JObject.Parse(json);
+            var managed = ManagedFieldJsonInjector.ExtractManaged(document, typeof(TEntity), _segmentation);
+            var entity = EntityJsonSerialization.MaterializeStored(
+                document,
+                typeof(TEntity),
+                JsonSerializer.Create(Settings)) as TEntity
+                ?? throw new InvalidDataException(
+                    $"JSON record '{path}' could not materialize Entity root '{RootType.FullName}'.");
+
+            if (validateExpectedId && !EqualityComparer<TKey>.Default.Equals(entity.Id, expectedId))
+            {
+                throw new InvalidDataException(
+                    $"JSON entity file '{path}' contains identity '{entity.Id}', not requested identity '{expectedId}'. " +
+                    "Repair the file name or stored identity deliberately.");
+            }
+
+            var canonical = locator.PathFor(entity.Id);
+            if (!JsonFileRegistry.PathComparer.Equals(canonical, Path.GetFullPath(path)))
+            {
+                throw new InvalidDataException(
+                    $"JSON entity file '{path}' contains identity '{entity.Id}', which maps to '{canonical}'. " +
+                    "Repair the file placement or stored identity deliberately; ambiguous storage is never accepted.");
+            }
+
+            return new KvRecord<TEntity>(entity, managed);
+        }
+        catch (InvalidDataException)
+        {
+            throw;
+        }
+        catch (JsonException exception)
+        {
+            throw Corrupt(path, exception);
+        }
+    }
+
+    private static string Encode(KvRecord<TEntity> record)
+    {
+        var document = JObject.FromObject(record.Entity, JsonSerializer.Create(Settings));
+        ManagedFieldJsonInjector.InjectManaged(document, record.Managed);
+        return document.ToString(Formatting.None);
+    }
+
+    private async Task Persist(string path, string payload, CancellationToken ct)
+    {
+        var parent = Path.GetDirectoryName(path)
+            ?? throw new InvalidOperationException($"JSON entity file '{path}' has no containing directory.");
+        if (_route.Policy.StorageLifecycle == StorageLifecycle.Managed)
+            Directory.CreateDirectory(parent);
+
+        var temporary = $"{path}.{Guid.CreateVersion7():N}.tmp";
+        try
+        {
+            await File.WriteAllTextAsync(temporary, payload, Utf8, ct).ConfigureAwait(false);
+            ct.ThrowIfCancellationRequested();
+            File.Move(temporary, path, overwrite: true);
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(temporary)) File.Delete(temporary);
+            }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+
+    private static void DemandPayloadBound(string payload, string operation)
+    {
+        var bytes = Utf8.GetByteCount(payload);
+        if (bytes <= Infrastructure.Constants.Provider.MaximumFileBytes) return;
+        throw new InvalidOperationException(
+            $"JSON {operation} for Entity root '{RootType.FullName}' would be {bytes} bytes and exceeds the " +
+            "64 MiB per-record safety bound. Reduce the record or use a database adapter.");
+    }
+
+    private void DemandReadableRoot()
+    {
+        if (Directory.Exists(_route.DirectoryPath)) return;
+        if (_route.Policy.StorageLifecycle == StorageLifecycle.External)
+        {
+            throw new DirectoryNotFoundException(
+                $"External JSON source '{_route.Source}' requires existing directory '{_route.DirectoryPath}'; Koan will not create it.");
+        }
+        if (_route.Policy.Access == DataSourceAccess.ReadOnly)
+        {
+            throw new DirectoryNotFoundException(
+                $"Read-only JSON source '{_route.Source}' requires existing directory '{_route.DirectoryPath}'; Koan will not create it.");
+        }
+    }
+
+    private JsonIndividualFileLocator CurrentLocator()
+    {
+        var partition = EntityContext.Current?.Partition;
+        var storage = _naming.ResolveStorage(RootType, partition, _services);
+        var locator = new JsonIndividualFileLocator(_route.DirectoryPath, _route.IndividualFilePath, storage);
+        if (!locator.UsesStorageToken && !string.IsNullOrWhiteSpace(partition))
+        {
+            throw new InvalidOperationException(
+                $"JSON IndividualFilePath '{_route.IndividualFilePath}' omits '{{storage}}' and cannot isolate partition " +
+                $"'{partition}'. Include '{{storage}}' or use an unpartitioned dedicated source.");
+        }
+        return locator;
+    }
+
+    private static InvalidDataException Corrupt(string path, Exception exception) => new(
+        $"Koan JSON could not read '{path}' because it does not contain a valid Entity object. " +
+        "Restore the file from a known-good copy or remove it deliberately; corrupt storage is never treated as empty.",
+        exception);
+}

--- a/src/Connectors/Data/Json/Runtime/JsonRoute.cs
+++ b/src/Connectors/Data/Json/Runtime/JsonRoute.cs
@@ -6,7 +6,12 @@ using Microsoft.Extensions.Configuration;
 namespace Koan.Data.Connector.Json.Runtime;
 
 /// <summary>One canonical, policy-bearing JSON source route. Resolving it never touches storage.</summary>
-internal sealed record JsonRoute(string Source, string DirectoryPath, DataSourcePlan Policy)
+internal sealed record JsonRoute(
+    string Source,
+    string DirectoryPath,
+    JsonStorageLayout Layout,
+    string IndividualFilePath,
+    DataSourcePlan Policy)
 {
     internal static JsonRoute Resolve(
         IConfiguration configuration,
@@ -34,9 +39,44 @@ internal sealed record JsonRoute(string Source, string DirectoryPath, DataSource
         }
 
         var directory = Path.GetFullPath(configured);
+
+        var configuredLayout = AdapterConnectionResolver.GetSourceSetting(
+            configuration,
+            sources,
+            Infrastructure.Constants.Provider.Name,
+            resolvedSource,
+            Infrastructure.Constants.Configuration.Layout,
+            defaults.Layout.ToString(),
+            owner);
+        if (!Enum.TryParse<JsonStorageLayout>(configuredLayout, ignoreCase: true, out var layout) ||
+            !Enum.IsDefined(layout))
+        {
+            throw new InvalidOperationException(
+                $"JSON layout '{configuredLayout}' is invalid for source '{resolvedSource}'. Choose " +
+                $"'{JsonStorageLayout.Aggregate}' or '{JsonStorageLayout.IndividualFiles}'.");
+        }
+
+        var individualFilePath = AdapterConnectionResolver.GetSourceSetting(
+            configuration,
+            sources,
+            Infrastructure.Constants.Provider.Name,
+            resolvedSource,
+            Infrastructure.Constants.Configuration.IndividualFilePath,
+            defaults.IndividualFilePath,
+            owner);
+        if (layout == JsonStorageLayout.IndividualFiles && string.IsNullOrWhiteSpace(individualFilePath))
+        {
+            throw new InvalidOperationException(
+                $"JSON individual-file path is not configured for source '{resolvedSource}'. Set " +
+                $"{Infrastructure.Constants.Configuration.Section}:IndividualFilePath or the source-specific " +
+                "json:IndividualFilePath.");
+        }
+
         return new JsonRoute(
             resolvedSource,
             directory,
+            layout,
+            individualFilePath,
             sources.GetPlan(resolvedSource, Infrastructure.Constants.Provider.Name, directory));
     }
 

--- a/src/Connectors/Data/Json/TECHNICAL.md
+++ b/src/Connectors/Data/Json/TECHNICAL.md
@@ -4,7 +4,7 @@ title: Koan.Data.Connector.Json - Technical Reference
 description: Bounded local JSON Entity persistence for Koan Data.
 packages: [Sylin.Koan.Data.Connector.Json]
 source: src/Connectors/Data/Json/
-last_updated: 2026-07-29
+last_updated: 2026-08-13
 ---
 
 ## Contract
@@ -12,14 +12,25 @@ last_updated: 2026-07-29
 The connector is an automatic Data floor with provider identity `json` and priority `0`. Package presence makes it
 available; source election or runtime use activates it. Application access remains the provider-neutral Entity API.
 
-`JsonDataOptions` exposes one provider decision: `DirectoryPath`, defaulting to `data`.
+`JsonDataOptions` exposes three provider decisions:
+
+- `DirectoryPath`, default `data`;
+- `Layout`, default `Aggregate`; and
+- `IndividualFilePath`, default `{storage}/{id}.json`.
 
 - Global: `Koan:Data:Json:DirectoryPath`
-- Per source: `Koan:Data:Sources:{source}:json:DirectoryPath`
+- Per source: `Koan:Data:Sources:{source}:json:{setting}`
 - Selection: `Koan:Data:Sources:{source}:Adapter=json`
 
-The physical name is the Entity root plus Koan's standard partition token. One file contains a JSON array of Entity
-objects. Entity-family type identity and framework-managed fields are stored by the shared Data Core codecs.
+The physical storage name is the Entity root plus Koan's standard partition token. `Aggregate` stores that Entity set
+as one JSON array file. `IndividualFiles` renders one relative path per identity and stores one JSON object there.
+Entity-family type identity and framework-managed fields use the same shared Data Core codecs in both layouts.
+
+An individual path contains exactly one `{id}` and at most one `{storage}` token. Both render through a UTF-8
+percent-style segment codec whose literal alphabet is lowercase ASCII, digits, `_`, and `-`; this distinguishes values
+that would otherwise collide on case-insensitive filesystems and prevents separator/traversal injection. Templates are
+relative `.json` paths, are lexically contained beneath `DirectoryPath`, and reject unknown tokens, empty segments,
+and traversal. Omitting `{storage}` claims the template for one Entity root/key pair and rejects partition use.
 
 ## Runtime ownership
 
@@ -40,12 +51,20 @@ and last complete target unchanged.
 The file is intentionally aggregate-based: unchanged record strings are reused, but every successful mutation still
 replaces the complete file.
 
+Individual layout retains no record snapshot. A fixed 64-stripe host-owned gate pool coordinates point mutations
+without memory growing with record count. Reads reopen the addressed file, so external edits completed before a read
+are visible in the same host. Scans derive the narrowest fixed search root/file name from the rendered template,
+enumerate matching paths, validate each document's identity back to its canonical path, and stop materialization at
+the requested candidate bound. A same-directory temporary file replaces only the addressed record. Remove never
+deletes parent directories or siblings.
+
 ## Bounds and persisted-input validation
 
-- Maximum canonical files per host: 1,024.
-- Maximum UTF-8 bytes per Entity file: 64 MiB, enforced before read materialization and before write.
+- Maximum cached Aggregate files per host: 1,024. IndividualFiles retains only a fixed 64-stripe gate pool.
+- Maximum UTF-8 bytes per Entity file: 64 MiB, enforced before read materialization and before write. In Aggregate
+  this bounds the set; in IndividualFiles it bounds one record.
 - Every array member must be an object assignable to the file's Entity root.
-- Every persisted identity must be unique.
+- Every persisted identity must be unique and, in IndividualFiles, must map back to the file containing it.
 - One canonical file cannot be interpreted by conflicting Entity root/key pairs in the same host.
 
 Violations throw corrective errors naming the affected path and the remediation. Corrupt or ambiguous storage is never
@@ -53,28 +72,32 @@ treated as empty.
 
 ## Source policy and health
 
-Managed/read-write reads may observe an absent file as empty; the first write or explicit ensure creates the directory
-and file. Read-only and External routes never create storage. A read-only route requires its directory to exist;
-External additionally requires the addressed Entity file.
+Managed/read-write reads may observe absent storage as empty; the first write creates the required path. Aggregate
+ensure creates its set file; IndividualFiles ensure creates the source directory. Read-only and External routes never
+create storage and require their source directory to exist. An External individual write additionally requires its
+addressed Entity file to exist.
 
 Health is selection-aware. Inactive JSON reports `Unknown` and touches no disk. Active managed/read-write health creates
 and probe-writes its directory. Active read-only/External health only verifies and enumerates an existing directory.
 
 ## Capabilities
 
-The KeyValue family supplies LINQ/full-filter behavior and row/container/database isolation. JSON declares scan filter
-execution plus `BulkUpsert` and `BulkDelete` because each bulk request is one physical replacement. It does not declare
-atomic batch, fast remove, indexes, native string queries, or provider-bounded paging.
+The KeyValue family supplies LINQ/full-filter behavior and row/container/database isolation. Both layouts declare
+bounded-candidate scan filter execution. Aggregate declares `BulkUpsert` and `BulkDelete` because each bulk request is
+one physical replacement. IndividualFiles intentionally omits those optimization claims and uses the KeyValue
+family's pointwise batch behavior. Neither layout declares atomic batch, fast remove, indexes, native string queries,
+or provider-bounded paging.
 
 `AllStream` and `QueryStream` therefore throw `QueryStreamRejectedException` before yielding. Required atomic batches
 also reject before execution. Physical compatibility maps reject because the provider owns its file shape.
 
 ## Durability boundary
 
-Same-directory replacement protects the last complete file from ordinary serialization and write failures. It is not
-an fsync/power-loss guarantee, transaction log, backup system, cross-process lock, or recovery protocol. The host cache
-does not observe concurrent external edits. Select a database connector when those guarantees or larger stores matter.
+Same-directory replacement protects the last complete addressed file from ordinary serialization and write failures.
+It is not an fsync/power-loss guarantee, transaction log, backup system, cross-process lock, compare-and-swap, or
+recovery protocol. Aggregate's host cache does not observe concurrent external edits; IndividualFiles observes disk on
+each read but does not make an external writer participate in its in-process gate. Select a database connector when
+those guarantees or larger stores matter.
 
-The real-file connector ledger passes 34/34 across CRUD, bulk, detached writes, restart, polymorphism, corruption,
-duplicate identity, byte/file bounds, canonical aliases, concurrent writes, policy, health, routing, partitions,
-managed isolation, mapping decline, instructions, atomic decline, and streaming decline.
+The real-file connector ledger covers the Aggregate compatibility contract and focused IndividualFiles evidence for
+placement, CRUD, external-edit visibility, extension data, path safety, partitions, and capability truth.

--- a/src/Connectors/Data/Mongo/Koan.Data.Connector.Mongo.csproj
+++ b/src/Connectors/Data/Mongo/Koan.Data.Connector.Mongo.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Description>MongoDB data provider for Koan: options binding and repository integration for document databases.</Description>

--- a/src/Connectors/Data/OpenSearch/Koan.Data.Connector.OpenSearch.csproj
+++ b/src/Connectors/Data/OpenSearch/Koan.Data.Connector.OpenSearch.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Connectors/Data/Postgres/Koan.Data.Connector.Postgres.csproj
+++ b/src/Connectors/Data/Postgres/Koan.Data.Connector.Postgres.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>Koan.Data.Connector.Postgres</AssemblyName>

--- a/src/Connectors/Data/Redis/Koan.Data.Connector.Redis.csproj
+++ b/src/Connectors/Data/Redis/Koan.Data.Connector.Redis.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Connectors/Data/SqlServer/Koan.Data.Connector.SqlServer.csproj
+++ b/src/Connectors/Data/SqlServer/Koan.Data.Connector.SqlServer.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>SQL Server provider for Koan relational data with JSON-projection pushdowns, guardrails, and governance.</Description>

--- a/src/Connectors/Data/Sqlite/Koan.Data.Connector.Sqlite.csproj
+++ b/src/Connectors/Data/Sqlite/Koan.Data.Connector.Sqlite.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Durable embedded SQLite provider for Koan Entity data with zero-config local storage, schema management, queries, and bounded paging.</Description>

--- a/src/Connectors/Data/Vector/InMemory/Koan.Data.Vector.Connector.InMemory.csproj
+++ b/src/Connectors/Data/Vector/InMemory/Koan.Data.Vector.Connector.InMemory.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.1</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Connectors/Data/Vector/Milvus/Koan.Data.Vector.Connector.Milvus.csproj
+++ b/src/Connectors/Data/Vector/Milvus/Koan.Data.Vector.Connector.Milvus.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Connectors/Data/Vector/Qdrant/Koan.Data.Vector.Connector.Qdrant.csproj
+++ b/src/Connectors/Data/Vector/Qdrant/Koan.Data.Vector.Connector.Qdrant.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Connectors/Data/Vector/SqliteVec/Koan.Data.Vector.Connector.SqliteVec.csproj
+++ b/src/Connectors/Data/Vector/SqliteVec/Koan.Data.Vector.Connector.SqliteVec.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.1</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Connectors/Data/Vector/Weaviate/Koan.Data.Vector.Connector.Weaviate.csproj
+++ b/src/Connectors/Data/Vector/Weaviate/Koan.Data.Vector.Connector.Weaviate.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Data.Abstractions/Koan.Data.Abstractions.csproj
+++ b/src/Koan.Data.Abstractions/Koan.Data.Abstractions.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Description>Provider-neutral Koan data contracts for Entity identity, repositories, structured queries, capabilities, and canonical operations.</Description>
     <PackageTags>$(CommonPackageTags);data;contracts;repository;entity;query;capabilities</PackageTags>
   </PropertyGroup>

--- a/src/Koan.Data.Core/Koan.Data.Core.csproj
+++ b/src/Koan.Data.Core/Koan.Data.Core.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Entity data runtime for Koan: provider election, routing, lifecycle, queries, paging, relationships, and canonical operations.</Description>

--- a/src/Koan.Data.Relational.Abstractions/Koan.Data.Relational.Abstractions.csproj
+++ b/src/Koan.Data.Relational.Abstractions/Koan.Data.Relational.Abstractions.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Inert relational schema, dialect, and DDL contracts for Koan Data providers.</Description>

--- a/src/Koan.Data.Relational.Npgsql/Koan.Data.Relational.Npgsql.csproj
+++ b/src/Koan.Data.Relational.Npgsql/Koan.Data.Relational.Npgsql.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Shared Npgsql repository mechanics for PostgreSQL-wire Koan Data providers.</Description>

--- a/src/Koan.Data.Relational/Koan.Data.Relational.csproj
+++ b/src/Koan.Data.Relational/Koan.Data.Relational.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Shared schema governance, SQL translation, and command mechanics for Koan relational Data providers.</Description>

--- a/src/Koan.Data.Vector.Abstractions/Koan.Data.Vector.Abstractions.csproj
+++ b/src/Koan.Data.Vector.Abstractions/Koan.Data.Vector.Abstractions.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Data.Vector/Koan.Data.Vector.csproj
+++ b/src/Koan.Data.Vector/Koan.Data.Vector.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Testing.Containers/Koan.Testing.Containers.csproj
+++ b/src/Koan.Testing.Containers/Koan.Testing.Containers.csproj
@@ -27,8 +27,6 @@
     <PackageReference Include="Testcontainers.Redis" />
     <PackageReference Include="Testcontainers.MsSql" />
     <PackageReference Include="Testcontainers.Couchbase" />
-    <!-- Pin Testcontainers' transitive SSH client above GHSA-q939-rpr3-3284. -->
-    <PackageReference Include="SSH.NET" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Koan.Testing.Hosting\Koan.Testing.Hosting.csproj" />

--- a/src/Koan.Testing.Containers/Koan.Testing.Containers.csproj
+++ b/src/Koan.Testing.Containers/Koan.Testing.Containers.csproj
@@ -27,6 +27,8 @@
     <PackageReference Include="Testcontainers.Redis" />
     <PackageReference Include="Testcontainers.MsSql" />
     <PackageReference Include="Testcontainers.Couchbase" />
+    <!-- Pin Testcontainers' transitive SSH client above GHSA-q939-rpr3-3284. -->
+    <PackageReference Include="SSH.NET" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Koan.Testing.Hosting\Koan.Testing.Hosting.csproj" />

--- a/tests/Suites/Data/Connector.Json/Koan.Data.Connector.Json.Tests/Specs/JsonStorageLayoutOptionsSpec.cs
+++ b/tests/Suites/Data/Connector.Json/Koan.Data.Connector.Json.Tests/Specs/JsonStorageLayoutOptionsSpec.cs
@@ -1,0 +1,14 @@
+namespace Koan.Data.Connector.Json.Tests.Specs;
+
+public sealed class JsonStorageLayoutOptionsSpec
+{
+    [Fact]
+    public void Defaults_preserve_aggregate_layout_and_offer_only_semantic_layout_names()
+    {
+        var options = new JsonDataOptions();
+
+        options.Layout.Should().Be(JsonStorageLayout.Aggregate);
+        options.IndividualFilePath.Should().Be("{storage}/{id}.json");
+        Enum.GetNames<JsonStorageLayout>().Should().Equal("Aggregate", "IndividualFiles");
+    }
+}

--- a/tests/Suites/Data/Connector.Json/Koan.Data.Connector.Json.Tests/Specs/Persistence/JsonIndividualFilesSpec.cs
+++ b/tests/Suites/Data/Connector.Json/Koan.Data.Connector.Json.Tests/Specs/Persistence/JsonIndividualFilesSpec.cs
@@ -1,0 +1,235 @@
+using Koan.Core;
+using Koan.Core.Hosting.App;
+using Koan.Data.Abstractions.Capabilities;
+using Koan.Testing.Integration;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Koan.Data.Connector.Json.Tests.Specs.Persistence;
+
+public sealed class JsonIndividualFilesSpec
+{
+    [Fact]
+    public async Task Configured_path_gives_each_entity_one_independent_file_and_observes_external_edits()
+    {
+        var root = TempRoot("placement");
+        try
+        {
+            await using var host = await Boot(root, "{id}/article.json");
+            using var hostScope = AppHost.PushScope(host.Services);
+
+            await new IndividualArticle { Id = "first-draft", Title = "First" }.Save();
+            await new IndividualArticle { Id = "second-draft", Title = "Second" }.Save();
+
+            var firstPath = Path.Combine(root, "first-draft", "article.json");
+            var secondPath = Path.Combine(root, "second-draft", "article.json");
+            File.Exists(firstPath).Should().BeTrue();
+            File.Exists(secondPath).Should().BeTrue();
+            JToken.Parse(await File.ReadAllTextAsync(firstPath)).Type.Should().Be(JTokenType.Object);
+
+            var mediaPath = Path.Combine(root, "first-draft", "media", "keep.txt");
+            Directory.CreateDirectory(Path.GetDirectoryName(mediaPath)!);
+            await File.WriteAllTextAsync(mediaPath, "owned by the application");
+
+            // Individual mode has no warm record snapshot: a Git checkout or another local file editor is visible on
+            // the next read in this same host.
+            var external = JObject.Parse(await File.ReadAllTextAsync(firstPath));
+            external["title"] = "Externally edited";
+            await File.WriteAllTextAsync(firstPath, external.ToString(Formatting.None));
+            (await IndividualArticle.Get("first-draft"))!.Title.Should().Be("Externally edited");
+
+            (await IndividualArticle.Remove("first-draft")).Should().BeTrue();
+            File.Exists(firstPath).Should().BeFalse();
+            File.Exists(mediaPath).Should().BeTrue("the JSON adapter owns the Entity file, not sibling media");
+            File.Exists(secondPath).Should().BeTrue();
+            (await IndividualArticle.All()).Should().ContainSingle(article => article.Id == "second-draft");
+        }
+        finally
+        {
+            Delete(root);
+        }
+    }
+
+    [Fact]
+    public async Task Extension_data_preserves_imported_unknown_properties_across_read_write()
+    {
+        var root = TempRoot("metadata");
+        var path = Path.Combine(root, "imported", "article.json");
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            await File.WriteAllTextAsync(
+                path,
+                """{"id":"imported","title":"Before","corpus":"legacy","arbitrary":{"rank":7}}""");
+
+            await using var host = await Boot(root, "{id}/article.json");
+            using var hostScope = AppHost.PushScope(host.Services);
+
+            var article = (await IndividualArticle.Get("imported"))!;
+            article.Metadata["corpus"]!.Value<string>().Should().Be("legacy");
+            article.Metadata["arbitrary"]!["rank"]!.Value<int>().Should().Be(7);
+
+            article.Title = "After";
+            await article.Save();
+
+            var persisted = JObject.Parse(await File.ReadAllTextAsync(path));
+            persisted["title"]!.Value<string>().Should().Be("After");
+            persisted["corpus"]!.Value<string>().Should().Be("legacy");
+            persisted["arbitrary"]!["rank"]!.Value<int>().Should().Be(7);
+            persisted.Property(nameof(IndividualArticle.Metadata), StringComparison.OrdinalIgnoreCase)
+                .Should().BeNull("JsonExtensionData remains top-level rather than adding a metadata wrapper");
+        }
+        finally
+        {
+            Delete(root);
+        }
+    }
+
+    [Fact]
+    public async Task Unsafe_identity_is_encoded_inside_the_root_and_unsafe_template_fails_correctively()
+    {
+        var safeRoot = TempRoot("safe-identity");
+        try
+        {
+            await using var host = await Boot(safeRoot, "{id}/article.json");
+            using var hostScope = AppHost.PushScope(host.Services);
+
+            await new IndividualArticle { Id = "../Draft", Title = "Contained" }.Save();
+            await new IndividualArticle { Id = "con", Title = "Portable" }.Save();
+            var files = Directory.EnumerateFiles(safeRoot, "article.json", SearchOption.AllDirectories).ToArray();
+            files.Should().HaveCount(2);
+            files.Should().OnlyContain(path => Path.GetFullPath(path).StartsWith(Path.GetFullPath(safeRoot)));
+            files.Should().OnlyContain(path => !Path.GetRelativePath(safeRoot, path).StartsWith(".."));
+            (await IndividualArticle.Get("../Draft"))!.Title.Should().Be("Contained");
+            (await IndividualArticle.Get("con"))!.Title.Should().Be("Portable");
+        }
+        finally
+        {
+            Delete(safeRoot);
+        }
+
+        var unsafeRoot = TempRoot("unsafe-template");
+        try
+        {
+            await using var host = await Boot(unsafeRoot, "../{id}.json");
+            using var hostScope = AppHost.PushScope(host.Services);
+
+            await FluentActions.Invoking(() =>
+                    new IndividualArticle { Id = "escape", Title = "Rejected" }.Save())
+                .Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage("*IndividualFilePath*relative*{id}*");
+        }
+        finally
+        {
+            Delete(unsafeRoot);
+        }
+    }
+
+    [Fact]
+    public async Task Individual_layout_uses_default_storage_path_and_does_not_claim_aggregate_bulk_writes()
+    {
+        var root = TempRoot("defaults");
+        try
+        {
+            await using var host = await Boot(root, individualFilePath: null);
+            using var hostScope = AppHost.PushScope(host.Services);
+
+            await new IndividualArticle { Id = "one", Title = "One" }.Save();
+            var path = Directory.EnumerateFiles(root, "*.json", SearchOption.AllDirectories)
+                .Should().ContainSingle().Subject;
+            Path.GetDirectoryName(path).Should().NotBe(Path.GetFullPath(root));
+
+            var repository = host.Services.GetRequiredService<IDataService>()
+                .GetRepository<IndividualArticle, string>();
+            var capabilities = DataCaps.Describe(repository, repository.GetType().Name);
+            capabilities.Has(DataCaps.Write.BulkUpsert).Should().BeFalse();
+            capabilities.Has(DataCaps.Write.BulkDelete).Should().BeFalse();
+            capabilities.Has(DataCaps.Query.FilterExecution).Should().BeTrue();
+        }
+        finally
+        {
+            Delete(root);
+        }
+    }
+
+    [Fact]
+    public async Task Storage_token_isolates_partitions_and_omitting_it_fails_closed_when_partitioned()
+    {
+        var isolatedRoot = TempRoot("partitioned");
+        try
+        {
+            await using var host = await Boot(isolatedRoot, individualFilePath: null);
+            using var hostScope = AppHost.PushScope(host.Services);
+
+            await IndividualArticle.Upsert(
+                new IndividualArticle { Id = "shared", Title = "Draft" },
+                "draft");
+            await IndividualArticle.Upsert(
+                new IndividualArticle { Id = "shared", Title = "Published" },
+                "published");
+
+            (await IndividualArticle.Get("shared", "draft"))!.Title.Should().Be("Draft");
+            (await IndividualArticle.Get("shared", "published"))!.Title.Should().Be("Published");
+            Directory.EnumerateFiles(isolatedRoot, "*.json", SearchOption.AllDirectories)
+                .Should().HaveCount(2);
+        }
+        finally
+        {
+            Delete(isolatedRoot);
+        }
+
+        var unqualifiedRoot = TempRoot("partition-rejected");
+        try
+        {
+            await using var host = await Boot(unqualifiedRoot, "{id}/article.json");
+            using var hostScope = AppHost.PushScope(host.Services);
+
+            await FluentActions.Invoking(() => IndividualArticle.Upsert(
+                    new IndividualArticle { Id = "shared", Title = "Rejected" },
+                    "draft"))
+                .Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage("*omits*{storage}*cannot isolate partition*draft*");
+        }
+        finally
+        {
+            Delete(unqualifiedRoot);
+        }
+    }
+
+    private static Task<IntegrationHost> Boot(string root, string? individualFilePath)
+    {
+        var settings = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["Koan:Environment"] = "Test",
+            ["Koan:Orchestration:ForceOrchestrationMode"] = "Standalone",
+            ["Koan:Data:Sources:Default:Adapter"] = "json",
+            ["Koan:Data:Sources:Default:json:DirectoryPath"] = root,
+            ["Koan:Data:Sources:Default:json:Layout"] = nameof(JsonStorageLayout.IndividualFiles)
+        };
+        if (individualFilePath is not null)
+            settings["Koan:Data:Sources:Default:json:IndividualFilePath"] = individualFilePath;
+
+        return KoanIntegrationHost.Configure()
+            .WithSettings(settings)
+            .ConfigureServices(static services => services.AddKoan())
+            .StartAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static string TempRoot(string purpose) =>
+        Path.Combine(Path.GetTempPath(), $"koan-json-individual-{purpose}-{Guid.CreateVersion7():N}");
+
+    private static void Delete(string root)
+    {
+        if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+    }
+
+    private sealed class IndividualArticle : Entity<IndividualArticle>
+    {
+        public string Title { get; set; } = "";
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> Metadata { get; set; } =
+            new Dictionary<string, JToken>(StringComparer.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- add additive Aggregate / IndividualFiles JSON storage layouts
- support safe per-entity path templates such as {id}/article.json`n- preserve unknown imported fields through standard [JsonExtensionData] metadata bags
- pin patched SSH.NET 2026.0.0 after the Aug 12 high-severity advisory blocked clean restores

## Validation
- JSON connector suite: 40/40 passed from a detached clean worktree
- product surface: current
- public API baselines: passed
- public package preview: Sylin.Koan.Data.Connector.Json.0.21.1.nupkg`n
Both commits include DCO signoff.