### PR TITLE
Preserve Data participation record ABI

### DIFF
--- a/src/Koan.Data.Core/DataAdapterParticipationInfo.cs
+++ b/src/Koan.Data.Core/DataAdapterParticipationInfo.cs
@@ -4,4 +4,18 @@ namespace Koan.Data.Core;
 public sealed record DataAdapterParticipationInfo(
     string Provider,
     string Source,
-    DataAdapterParticipationRole Role = DataAdapterParticipationRole.Explicit);
+    DataAdapterParticipationRole Role = DataAdapterParticipationRole.Explicit)
+{
+    /// <summary>Preserves the original provider/source binary contract.</summary>
+    public DataAdapterParticipationInfo(string Provider, string Source)
+        : this(Provider, Source, DataAdapterParticipationRole.Explicit)
+    {
+    }
+
+    /// <summary>Preserves the original two-value positional shape.</summary>
+    public void Deconstruct(out string Provider, out string Source)
+    {
+        Provider = this.Provider;
+        Source = this.Source;
+    }
+}

--- a/tests/Suites/Data/Core/Koan.Tests.Data.Core/Specs/Hosting/DataAdapterParticipationSpec.cs
+++ b/tests/Suites/Data/Core/Koan.Tests.Data.Core/Specs/Hosting/DataAdapterParticipationSpec.cs
@@ -15,6 +15,18 @@ namespace Koan.Tests.Data.Core.Specs.Hosting;
 public sealed class DataAdapterParticipationSpec
 {
     [Fact]
+    public void Participation_info_preserves_the_original_two_value_shape()
+    {
+        var participation = new DataAdapterParticipationInfo("provider", "source");
+
+        var (provider, source) = participation;
+
+        provider.Should().Be("provider");
+        source.Should().Be("source");
+        participation.Role.Should().Be(DataAdapterParticipationRole.Explicit);
+    }
+
+    [Fact]
     public void Repository_use_records_canonical_provider_and_every_logical_source()
     {
         using var services = Services();


### PR DESCRIPTION
## Fix
Restore the published Data.Core 0.21 two-argument DataAdapterParticipationInfo constructor and two-output Deconstruct while retaining the new Role member.

## Evidence
- focused DataAdapterParticipationSpec: 5/5 passed
- public package validation against Data.Core 0.21.0: passed
- package preview: Sylin.Koan.Data.Core 0.21.2`n
This unblocks the main package workflow, which failed before NuGet publication. The commit includes DCO signoff.