### PR TITLE
Publish JSON individual-file persistence 0.21.2

### DIFF
--- a/src/Koan.Data.Core/DataAdapterParticipationInfo.cs
+++ b/src/Koan.Data.Core/DataAdapterParticipationInfo.cs
@@ -4,4 +4,18 @@ namespace Koan.Data.Core;
 public sealed record DataAdapterParticipationInfo(
     string Provider,
     string Source,
-    DataAdapterParticipationRole Role = DataAdapterParticipationRole.Explicit);
+    DataAdapterParticipationRole Role = DataAdapterParticipationRole.Explicit)
+{
+    /// <summary>Preserves the original provider/source binary contract.</summary>
+    public DataAdapterParticipationInfo(string Provider, string Source)
+        : this(Provider, Source, DataAdapterParticipationRole.Explicit)
+    {
+    }
+
+    /// <summary>Preserves the original two-value positional shape.</summary>
+    public void Deconstruct(out string Provider, out string Source)
+    {
+        Provider = this.Provider;
+        Source = this.Source;
+    }
+}

--- a/tests/Suites/Data/Core/Koan.Tests.Data.Core/Specs/Hosting/DataAdapterParticipationSpec.cs
+++ b/tests/Suites/Data/Core/Koan.Tests.Data.Core/Specs/Hosting/DataAdapterParticipationSpec.cs
@@ -15,6 +15,18 @@ namespace Koan.Tests.Data.Core.Specs.Hosting;
 public sealed class DataAdapterParticipationSpec
 {
     [Fact]
+    public void Participation_info_preserves_the_original_two_value_shape()
+    {
+        var participation = new DataAdapterParticipationInfo("provider", "source");
+
+        var (provider, source) = participation;
+
+        provider.Should().Be("provider");
+        source.Should().Be("source");
+        participation.Role.Should().Be(DataAdapterParticipationRole.Explicit);
+    }
+
+    [Fact]
     public void Repository_use_records_canonical_provider_and_every_logical_source()
     {
         using var services = Services();


### PR DESCRIPTION
## Release retry
Promotes the API-compatible current dev tree after the first package run stopped before NuGet push.

- release tree: ad3143e3c06d1a3ada71dd1af6181e66592c588`n- origin/dev tree: ad3143e3c06d1a3ada71dd1af6181e66592c588`n- expected JSON package: Sylin.Koan.Data.Connector.Json 0.21.2`n
## Evidence
- API hotfix PR #125 gate: green
- participation tests: 5/5 passed
- Data.Core PublicRelease pack against 0.21.0: passed
- prior JSON connector and full-solution evidence remains green

The promotion commit includes DCO signoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role information to data adapter participation details, defaulting to explicit participation.
  * Preserved compatibility with existing two-argument construction and two-value deconstruction patterns.

* **Tests**
  * Added coverage confirming the default role and legacy two-value access pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->