### PR TITLE
Fix NuGet dependency compatibility closure

### DIFF
--- a/src/Koan.Communication/version.json
+++ b/src/Koan.Communication/version.json
@@ -3,6 +3,9 @@
   "version": "0.20",
   "versionHeightOffset": -1,
   "pathFilters": [
-    "."
+    ".",
+    "../Koan.Core/version.json",
+    "../Koan.Data.Abstractions/version.json",
+    "../Koan.Data.Core/version.json"
   ]
 }

--- a/src/Koan.Data.Cutover/Koan.Data.Cutover.csproj
+++ b/src/Koan.Data.Cutover/Koan.Data.Cutover.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <PackageValidationBaselineVersion>0.22.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Web/version.json
+++ b/src/Koan.Web/version.json
@@ -3,6 +3,9 @@
   "version": "0.20",
   "versionHeightOffset": -1,
   "pathFilters": [
-    "."
+    ".",
+    "../Koan.Core/version.json",
+    "../Koan.Data.Abstractions/version.json",
+    "../Koan.Data.Core/version.json"
   ]
 }


### PR DESCRIPTION
## Summary
- rebuild Koan.Web when Core/Data compatibility intent changes
- rebuild Koan.Communication when Core/Data compatibility intent changes
- record the newly immutable Sylin.Koan.Data.Cutover 0.22.0 API baseline
- publish a coherent App + JSON connector dependency graph for package-only consumers

## Verification
- focused packaging/versioning suite: 26/26
- standalone-clone API baseline gate: 77/77 configured, 0 pending
- packed Communication 0.20.7, Web 0.20.5, Sylin.Koan 0.20.13, and App 0.20.13
- inspected nuspec ranges: Web/Communication now require Data.Abstractions 0.21.1 and Data.Core 0.21.2

Replaces #127 because GitHub did not dispatch a new Actions run for its updated head.