### PR TITLE
Fix stable release tag validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
 
           dotnet tool restore
           if ($LASTEXITCODE -ne 0) { throw 'Local tool restore failed.' }
-          $computed = (dotnet nbgv get-version -v SimpleVersion).Trim()
+          $computed = (dotnet nbgv get-version --public-release=true -v NuGetPackageVersion).Trim()
           if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($computed)) {
             throw 'Nerdbank.GitVersioning did not produce a package version.'
           }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
   "version": "1.0",
-  "versionHeightOffset": -2
+  "versionHeightOffset": -3
 }


### PR DESCRIPTION
The v1.0.0 release stopped before build or publication because NBGV SimpleVersion rendered 1.0. Compare the tag with public NuGetPackageVersion instead, and retain the merged commit at package version 1.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected package version calculation for public releases.
  * Updated versioning configuration to ensure release versions are generated accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->