### PR TITLE
Adopt the shared 1.0 API baseline

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,21 +1,8 @@
 <Project>
   <PropertyGroup>
-    <!-- Bootstrap 1.0.0 keeps the historical package API floors below and in project files.
-         After the complete 1.0.0 train is public, set this once to 1.0.0. It then overrides those
-         historical floors as the shared SDK package-validation baseline for every assembly package. -->
-    <KoanTrainBaselineVersion Condition="'$(KoanTrainBaselineVersion)' == ''" />
+    <!-- Every assembly package validates against the preceding public train. -->
+    <KoanTrainBaselineVersion Condition="'$(KoanTrainBaselineVersion)' == ''">1.0.0</KoanTrainBaselineVersion>
     <PackageValidationBaselineVersion Condition="'$(KoanTrainBaselineVersion)' != '' and '$(IncludeBuildOutput)' != 'false'">$(KoanTrainBaselineVersion)</PackageValidationBaselineVersion>
-
-    <!-- Historical bootstrap floors. Keep these until the shared 1.0.0 baseline is established. -->
-    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == '' and '$(PackageId)' == 'Sylin.Koan.Storage.Abstractions'">0.20.0</PackageValidationBaselineVersion>
-    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == '' and '$(PackageId)' == 'Sylin.Koan.Storage'">0.20.0</PackageValidationBaselineVersion>
-    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == '' and '$(PackageId)' == 'Sylin.Koan.Storage.Connector.Local'">0.20.0</PackageValidationBaselineVersion>
-    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == '' and '$(PackageId)' == 'Sylin.Koan.Media.Abstractions'">0.20.0</PackageValidationBaselineVersion>
-    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == '' and '$(PackageId)' == 'Sylin.Koan.Media.Core'">0.20.0</PackageValidationBaselineVersion>
-    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == '' and '$(PackageId)' == 'Sylin.Koan.Media.Web'">0.20.0</PackageValidationBaselineVersion>
-    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == '' and '$(PackageId)' == 'Sylin.Koan.Web.Auth.Connector.Google'">0.20.0</PackageValidationBaselineVersion>
-    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == '' and '$(PackageId)' == 'Sylin.Koan.Web.Auth.Connector.Microsoft'">0.20.0</PackageValidationBaselineVersion>
-    <PackageValidationBaselineVersion Condition="'$(PackageValidationBaselineVersion)' == '' and '$(PackageId)' == 'Sylin.Koan.Web.Auth.Connector.Discord'">0.20.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -26,8 +13,8 @@
   <Target Name="ValidateKoanPackageTrainBaseline"
           BeforeTargets="Pack"
           Condition="'$(PublicRelease)' == 'true' and '$(IsPackable)' != 'false'">
-    <Error Condition="'$(PackageVersion)' != '1.0.0' and '$(KoanTrainBaselineVersion)' == ''"
-           Text="Public package train $(PackageVersion) requires KoanTrainBaselineVersion. After the complete 1.0.0 train is public, set the central property to 1.0.0 before packing another release." />
+    <Error Condition="'$(KoanTrainBaselineVersion)' == ''"
+           Text="Public package train $(PackageVersion) requires the central KoanTrainBaselineVersion." />
   </Target>
 
   <!-- NBGV computes every package version from the root release line and shared Git height. -->

--- a/docs/decisions/ARCH-0124-single-package-release-train.md
+++ b/docs/decisions/ARCH-0124-single-package-release-train.md
@@ -95,17 +95,16 @@ change the selected set.
 
 ### API-baseline transition
 
-The first shared train has no shared public predecessor. Its `1.0.0` release therefore retains each
-assembly package's existing historical baseline where one exists while packing the complete active
-inventory at `1.0.0`.
+The first shared train had no shared public predecessor, so its `1.0.0` release retained each
+assembly package's existing historical baseline while packing the complete active inventory. Once
+that train was public, `KoanTrainBaselineVersion=1.0.0` became the single shared
+`PackageValidationBaselineVersion` source and the historical project-local declarations were
+removed.
 
-After `1.0.0` is public for the complete inventory, one follow-up change sets
-`KoanTrainBaselineVersion=1.0.0` centrally; it becomes the shared
-`PackageValidationBaselineVersion` source and the historical project-local declarations can then be
-removed. MSBuild rejects any post-bootstrap public pack while the central property is empty. The next
-release validates every assembly package against that common predecessor. Content-only packages
-remain covered by dependency-shape and package-consumer proof. The policy is evaluated from source;
-it does not discover or choose baselines from live registry state.
+Each later release validates every assembly package against the preceding complete train. After a
+train is public, maintainers advance the one central baseline before preparing the following train.
+Content-only packages remain covered by dependency-shape and package-consumer proof. The policy is
+evaluated from source; it does not discover or choose baselines from live registry state.
 
 ## Consequences
 

--- a/docs/engineering/versioning.md
+++ b/docs/engineering/versioning.md
@@ -37,10 +37,10 @@ Internal Koan dependencies remain bounded to the next breaking line by
 `build/compat-ranges.targets`. A 1.x package emits `[1.x.y, 2.0.0)`, so an incompatible major mix
 fails at restore even though normal releases use one aligned version.
 
-Assembly packages validate against the preceding public train. The bootstrap `1.0.0` train keeps
-the historical package baselines. Any later `PublicRelease` pack fails while
-`KoanTrainBaselineVersion` is empty. After the complete train is public, set that central property to
-`1.0.0`; it becomes the shared SDK `PackageValidationBaselineVersion` source for subsequent releases.
+Assembly packages validate against the preceding public train. `KoanTrainBaselineVersion` is the
+single SDK `PackageValidationBaselineVersion` source and is currently `1.0.0`; there are no
+project-local baseline declarations. After publishing a complete train, advance this central value
+to that released version before preparing the following train.
 
 See [NuGet publishing](nuget-publishing.md) and
 [ARCH-0124](../decisions/ARCH-0124-single-package-release-train.md).

--- a/src/Connectors/AI/LMStudio/Koan.AI.Connector.LMStudio.csproj
+++ b/src/Connectors/AI/LMStudio/Koan.AI.Connector.LMStudio.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <PackageValidationBaselineVersion>0.20.0</PackageValidationBaselineVersion>
     <Description>LM Studio provider for Koan AI (chat, streaming, embeddings) with auto-discovery.</Description>
     <PackageTags>$(CommonPackageTags);ai;lmstudio;provider</PackageTags>
   </PropertyGroup>

--- a/src/Connectors/AI/Ollama/Koan.AI.Connector.Ollama.csproj
+++ b/src/Connectors/AI/Ollama/Koan.AI.Connector.Ollama.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <PackageValidationBaselineVersion>0.20.0</PackageValidationBaselineVersion>
     <Description>Ollama provider for Koan AI (chat, streaming, embeddings) with Dev auto-discovery.</Description>
     <PackageTags>$(CommonPackageTags);ai;ollama;provider</PackageTags>
   </PropertyGroup>

--- a/src/Connectors/AI/Onnx/Koan.AI.Connector.Onnx.csproj
+++ b/src/Connectors/AI/Onnx/Koan.AI.Connector.Onnx.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PackageValidationBaselineVersion>0.20.1</PackageValidationBaselineVersion>
     <AssemblyName>Koan.AI.Connector.Onnx</AssemblyName>
     <RootNamespace>Koan.AI.Connector.Onnx</RootNamespace>
     <Description>In-process embedding generation for Koan via ONNX Runtime. Runs a local sentence-embedding model (e.g. all-MiniLM-L6-v2) with a WordPiece tokenizer entirely in-process — no model server, no network. The embeddings rung of the single-binary tier.</Description>

--- a/src/Connectors/Communication/RabbitMq/Koan.Communication.Connector.RabbitMq.csproj
+++ b/src/Connectors/Communication/RabbitMq/Koan.Communication.Connector.RabbitMq.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.8</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Connectors/Data/Cockroach/Koan.Data.Connector.Cockroach.csproj
+++ b/src/Connectors/Data/Cockroach/Koan.Data.Connector.Cockroach.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>Koan.Data.Connector.Cockroach</AssemblyName>

--- a/src/Connectors/Data/Couchbase/Koan.Data.Connector.Couchbase.csproj
+++ b/src/Connectors/Data/Couchbase/Koan.Data.Connector.Couchbase.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Description>Couchbase provider for Koan Data with direct KV, SQL++, CAS, compact mappings, and neutral source integration.</Description>

--- a/src/Connectors/Data/ElasticSearch/Koan.Data.Connector.ElasticSearch.csproj
+++ b/src/Connectors/Data/ElasticSearch/Koan.Data.Connector.ElasticSearch.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Connectors/Data/InMemory/Koan.Data.Connector.InMemory.csproj
+++ b/src/Connectors/Data/InMemory/Koan.Data.Connector.InMemory.csproj
@@ -9,7 +9,6 @@
   </ItemGroup>
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.3</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Host-ephemeral Koan Entity adapter with detached snapshots, exact isolation, and bounded in-process state.</Description>

--- a/src/Connectors/Data/Json/Koan.Data.Connector.Json.csproj
+++ b/src/Connectors/Data/Json/Koan.Data.Connector.Json.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Zero-configuration JSON persistence for small Koan applications, tests, and local development.</Description>

--- a/src/Connectors/Data/Mongo/Koan.Data.Connector.Mongo.csproj
+++ b/src/Connectors/Data/Mongo/Koan.Data.Connector.Mongo.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Description>MongoDB data provider for Koan: options binding and repository integration for document databases.</Description>

--- a/src/Connectors/Data/OpenSearch/Koan.Data.Connector.OpenSearch.csproj
+++ b/src/Connectors/Data/OpenSearch/Koan.Data.Connector.OpenSearch.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Connectors/Data/Postgres/Koan.Data.Connector.Postgres.csproj
+++ b/src/Connectors/Data/Postgres/Koan.Data.Connector.Postgres.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>Koan.Data.Connector.Postgres</AssemblyName>

--- a/src/Connectors/Data/Redis/Koan.Data.Connector.Redis.csproj
+++ b/src/Connectors/Data/Redis/Koan.Data.Connector.Redis.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Connectors/Data/SqlServer/Koan.Data.Connector.SqlServer.csproj
+++ b/src/Connectors/Data/SqlServer/Koan.Data.Connector.SqlServer.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>SQL Server provider for Koan relational data with JSON-projection pushdowns, guardrails, and governance.</Description>

--- a/src/Connectors/Data/Sqlite/Koan.Data.Connector.Sqlite.csproj
+++ b/src/Connectors/Data/Sqlite/Koan.Data.Connector.Sqlite.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Durable embedded SQLite provider for Koan Entity data with zero-config local storage, schema management, queries, and bounded paging.</Description>

--- a/src/Connectors/Data/Vector/InMemory/Koan.Data.Vector.Connector.InMemory.csproj
+++ b/src/Connectors/Data/Vector/InMemory/Koan.Data.Vector.Connector.InMemory.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.1</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Connectors/Data/Vector/Milvus/Koan.Data.Vector.Connector.Milvus.csproj
+++ b/src/Connectors/Data/Vector/Milvus/Koan.Data.Vector.Connector.Milvus.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Connectors/Data/Vector/Qdrant/Koan.Data.Vector.Connector.Qdrant.csproj
+++ b/src/Connectors/Data/Vector/Qdrant/Koan.Data.Vector.Connector.Qdrant.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Connectors/Data/Vector/SqliteVec/Koan.Data.Vector.Connector.SqliteVec.csproj
+++ b/src/Connectors/Data/Vector/SqliteVec/Koan.Data.Vector.Connector.SqliteVec.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.1</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Connectors/Data/Vector/Weaviate/Koan.Data.Vector.Connector.Weaviate.csproj
+++ b/src/Connectors/Data/Vector/Weaviate/Koan.Data.Vector.Connector.Weaviate.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Connectors/Web/Auth/Test/Koan.Web.Auth.Connector.Test.csproj
+++ b/src/Connectors/Web/Auth/Test/Koan.Web.Auth.Connector.Test.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <PackageValidationBaselineVersion>0.20.1</PackageValidationBaselineVersion>
     <Description>Test identity provider for Koan Web Auth: local login UI, token issuance for demos, and development-only wiring.</Description>
     <PackageTags>$(CommonPackageTags);web;auth;test-provider;identity</PackageTags>
   </PropertyGroup>

--- a/src/Koan.AI.Contracts/Koan.AI.Contracts.csproj
+++ b/src/Koan.AI.Contracts/Koan.AI.Contracts.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <PackageValidationBaselineVersion>0.20.0</PackageValidationBaselineVersion>
     <Description>Inert Koan AI contracts for provider adapters, routing, model selection, prompts, and multimodal request and result shapes.</Description>
     <PackageTags>$(CommonPackageTags);ai;contracts;adapters;routing;multimodal</PackageTags>
   </PropertyGroup>

--- a/src/Koan.AI/Koan.AI.csproj
+++ b/src/Koan.AI/Koan.AI.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <PackageValidationBaselineVersion>0.20.0</PackageValidationBaselineVersion>
     <Description>Koan AI semantic client, capability-aware routing, provider composition, source health, and startup inspection.</Description>
     <PackageTags>$(CommonPackageTags);ai;facade;runtime</PackageTags>
   </PropertyGroup>

--- a/src/Koan.Cache.Abstractions/Koan.Cache.Abstractions.csproj
+++ b/src/Koan.Cache.Abstractions/Koan.Cache.Abstractions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.1</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Cache.Adapter.Sqlite/Koan.Cache.Adapter.Sqlite.csproj
+++ b/src/Koan.Cache.Adapter.Sqlite/Koan.Cache.Adapter.Sqlite.csproj
@@ -6,7 +6,6 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>Koan.Cache.Adapter.Sqlite</AssemblyName>
     <RootNamespace>Koan.Cache.Adapter.Sqlite</RootNamespace>
-    <PackageValidationBaselineVersion>0.20.1</PackageValidationBaselineVersion>
     <Description>SQLite-backed persistent L1 cache store for Koan.Cache. Provides on-disk cache persistence with tag indexing and TTL eviction. Preempts the default Memory store by ProviderPriority.</Description>
     <PackageTags>$(CommonPackageTags);cache;adapter;sqlite;l1;persistent</PackageTags>
   </PropertyGroup>

--- a/src/Koan.Cache/Koan.Cache.csproj
+++ b/src/Koan.Cache/Koan.Cache.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Canon.Web/Koan.Canon.Web.csproj
+++ b/src/Koan.Canon.Web/Koan.Canon.Web.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Canon/Koan.Canon.csproj
+++ b/src/Koan.Canon/Koan.Canon.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.3</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Functional Koan Canon runtime with automatic model and pipeline composition.</Description>

--- a/src/Koan.Classification.Contracts/Koan.Classification.Contracts.csproj
+++ b/src/Koan.Classification.Contracts/Koan.Classification.Contracts.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Classification/Koan.Classification.csproj
+++ b/src/Koan.Classification/Koan.Classification.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Communication/Koan.Communication.csproj
+++ b/src/Koan.Communication/Koan.Communication.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.5</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Core/Koan.Core.csproj
+++ b/src/Koan.Core/Koan.Core.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.4</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Composition and runtime substrate for Koan modules: lifecycle, context, provider catalogs, readiness, discovery, facts, and build provenance.</Description>

--- a/src/Koan.Data.Abstractions/Koan.Data.Abstractions.csproj
+++ b/src/Koan.Data.Abstractions/Koan.Data.Abstractions.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <Description>Provider-neutral Koan data contracts for Entity identity, repositories, structured queries, capabilities, and canonical operations.</Description>
     <PackageTags>$(CommonPackageTags);data;contracts;repository;entity;query;capabilities</PackageTags>
   </PropertyGroup>

--- a/src/Koan.Data.Core/Koan.Data.Core.csproj
+++ b/src/Koan.Data.Core/Koan.Data.Core.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Entity data runtime for Koan: provider election, routing, lifecycle, queries, paging, relationships, and canonical operations.</Description>

--- a/src/Koan.Data.Relational.Abstractions/Koan.Data.Relational.Abstractions.csproj
+++ b/src/Koan.Data.Relational.Abstractions/Koan.Data.Relational.Abstractions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Inert relational schema, dialect, and DDL contracts for Koan Data providers.</Description>

--- a/src/Koan.Data.Relational.Npgsql/Koan.Data.Relational.Npgsql.csproj
+++ b/src/Koan.Data.Relational.Npgsql/Koan.Data.Relational.Npgsql.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Shared Npgsql repository mechanics for PostgreSQL-wire Koan Data providers.</Description>

--- a/src/Koan.Data.Relational/Koan.Data.Relational.csproj
+++ b/src/Koan.Data.Relational/Koan.Data.Relational.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Shared schema governance, SQL translation, and command mechanics for Koan relational Data providers.</Description>

--- a/src/Koan.Data.SoftDelete/Koan.Data.SoftDelete.csproj
+++ b/src/Koan.Data.SoftDelete/Koan.Data.SoftDelete.csproj
@@ -6,7 +6,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Koan.Data.SoftDelete</AssemblyName>
     <RootNamespace>Koan.Data.SoftDelete</RootNamespace>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <Description>Opt-in recoverable Entity deletion: ordinary reads hide soft-removed rows while type-targeted recycle-bin, restore, and purge verbs remain explicit.</Description>
     <PackageTags>$(CommonPackageTags);soft-delete;audit;recycle-bin</PackageTags>
   </PropertyGroup>

--- a/src/Koan.Data.Vector.Abstractions/Koan.Data.Vector.Abstractions.csproj
+++ b/src/Koan.Data.Vector.Abstractions/Koan.Data.Vector.Abstractions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Data.Vector/Koan.Data.Vector.csproj
+++ b/src/Koan.Data.Vector/Koan.Data.Vector.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.21.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Identity.Tenancy/Koan.Identity.Tenancy.csproj
+++ b/src/Koan.Identity.Tenancy/Koan.Identity.Tenancy.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Identity.Web/Koan.Identity.Web.csproj
+++ b/src/Koan.Identity.Web/Koan.Identity.Web.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Identity/Koan.Identity.csproj
+++ b/src/Koan.Identity/Koan.Identity.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Jobs.Testing/Koan.Jobs.Testing.csproj
+++ b/src/Koan.Jobs.Testing/Koan.Jobs.Testing.csproj
@@ -4,7 +4,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
-    <PackageValidationBaselineVersion>0.20.1</PackageValidationBaselineVersion>
     <Description>Deterministically drive Koan Jobs through its production execution engine from any test framework.</Description>
     <PackageTags>$(CommonPackageTags);jobs;testing;deterministic;integration-testing</PackageTags>
   </PropertyGroup>

--- a/src/Koan.Jobs/Koan.Jobs.csproj
+++ b/src/Koan.Jobs/Koan.Jobs.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Mcp.Explorer/Koan.Mcp.Explorer.csproj
+++ b/src/Koan.Mcp.Explorer/Koan.Mcp.Explorer.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Human inspection console for Koan MCP: caller-visible tools, governed try-it, and fail-closed access-map diagnostics.</Description>

--- a/src/Koan.Mcp.Operations/Koan.Mcp.Operations.csproj
+++ b/src/Koan.Mcp.Operations/Koan.Mcp.Operations.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Governed MCP operations for Koan Jobs and Cache, with explicit enablement, exact grants, destructive confirmation, and mutation audit.</Description>

--- a/src/Koan.Mcp/Koan.Mcp.csproj
+++ b/src/Koan.Mcp/Koan.Mcp.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.3</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Model Context Protocol integration for Koan entity endpoints: discovery, schema, execution, and transports.</Description>

--- a/src/Koan.Observability/Koan.Observability.csproj
+++ b/src/Koan.Observability/Koan.Observability.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.3</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Redis.Abstractions/Koan.Redis.Abstractions.csproj
+++ b/src/Koan.Redis.Abstractions/Koan.Redis.Abstractions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Inert connection-lifecycle contracts for Koan modules that share a Redis backend.</Description>

--- a/src/Koan.Redis/Koan.Redis.csproj
+++ b/src/Koan.Redis/Koan.Redis.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.0</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Shared Redis backend lifecycle, discovery, and connection pooling for Koan adapters.</Description>

--- a/src/Koan.Security.Trust/Koan.Security.Trust.csproj
+++ b/src/Koan.Security.Trust/Koan.Security.Trust.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Tenancy.Web/Koan.Tenancy.Web.csproj
+++ b/src/Koan.Tenancy.Web/Koan.Tenancy.Web.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Tenancy/Koan.Tenancy.csproj
+++ b/src/Koan.Tenancy/Koan.Tenancy.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Testing.Containers/Koan.Testing.Containers.csproj
+++ b/src/Koan.Testing.Containers/Koan.Testing.Containers.csproj
@@ -11,7 +11,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <Description>Koan test harness — xUnit v3 Testcontainers fixtures (KoanContainerFixture / KoanDataSpec) for engine-backed integration tests.</Description>
     <PackageTags>$(CommonPackageTags);testing;integration-testing;testcontainers;xunit</PackageTags>
     <!-- ARCH-0091: xUnit1051 (thread TestContext cancellation token) is advisory; was suppressed

--- a/src/Koan.Testing.Hosting/Koan.Testing.Hosting.csproj
+++ b/src/Koan.Testing.Hosting/Koan.Testing.Hosting.csproj
@@ -11,7 +11,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
-    <PackageValidationBaselineVersion>0.20.3</PackageValidationBaselineVersion>
     <Description>Koan test harness — the AddKoan() integration host (KoanIntegrationHost), xUnit-agnostic. Boot a real compiled Koan composition in your app's tests.</Description>
     <PackageTags>$(CommonPackageTags);testing;integration-testing;harness</PackageTags>
   </PropertyGroup>

--- a/src/Koan.Testing/Koan.Testing.csproj
+++ b/src/Koan.Testing/Koan.Testing.csproj
@@ -13,7 +13,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <Description>Koan conformance kit — your app inherits a test suite. Subclass EntityConformanceSpecs&lt;T&gt; (one method per entity); trait-gated batteries run round-trip, pushdown-vs-reference-oracle, paging, partition isolation, caching and embedding conformance automatically.</Description>
     <PackageTags>$(CommonPackageTags);testing;conformance;integration-testing;xunit</PackageTags>
     <!-- ARCH-0091: xUnit1051 (thread TestContext cancellation) is advisory; re-add (src/ doesn't inherit tests/). -->

--- a/src/Koan.Web.Admin/Koan.Web.Admin.csproj
+++ b/src/Koan.Web.Admin/Koan.Web.Admin.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PackageValidationBaselineVersion>0.20.1</PackageValidationBaselineVersion>
     <Description>Development-only, read-only dashboard for sanitized Koan runtime, health, and provenance insight.</Description>
     <PackageTags>$(CommonPackageTags);admin;dashboard;diagnostics;development;provenance</PackageTags>
   </PropertyGroup>

--- a/src/Koan.Web.Auth.Abstractions/Koan.Web.Auth.Abstractions.csproj
+++ b/src/Koan.Web.Auth.Abstractions/Koan.Web.Auth.Abstractions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.1</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Web.Auth.Server/Koan.Web.Auth.Server.csproj
+++ b/src/Koan.Web.Auth.Server/Koan.Web.Auth.Server.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Koan.Web.Auth.Server</RootNamespace>

--- a/src/Koan.Web.Auth/Koan.Web.Auth.csproj
+++ b/src/Koan.Web.Auth/Koan.Web.Auth.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.3</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Koan.Web.Extensions/Koan.Web.Extensions.csproj
+++ b/src/Koan.Web.Extensions/Koan.Web.Extensions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.1</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Entity-first REST exposure plus optional moderation, audit, and capability-policy controllers for Koan web applications.</Description>

--- a/src/Koan.Web.OpenApi/Koan.Web.OpenApi.csproj
+++ b/src/Koan.Web.OpenApi/Koan.Web.OpenApi.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Description>OpenAPI 3.1 document and governed interactive UI projection for Koan web applications.</Description>

--- a/src/Koan.Web.OpenGraph/Koan.Web.OpenGraph.csproj
+++ b/src/Koan.Web.OpenGraph/Koan.Web.OpenGraph.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.1</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Host-owned Entity social-card projection and automatic OpenGraph/Twitter metadata injection for Koan SPA shells.</Description>

--- a/src/Koan.Web.Sse/Koan.Web.Sse.csproj
+++ b/src/Koan.Web.Sse/Koan.Web.Sse.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.2</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Controller-first Server-Sent Events projection with one typed result model for Koan web applications and framework transports.</Description>

--- a/src/Koan.Web/Koan.Web.csproj
+++ b/src/Koan.Web/Koan.Web.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.3</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Controller-first ASP.NET Core projection for Koan Entities with health, startup composition, and redacted runtime facts.</Description>

--- a/src/Koan.ZenGarden.Contracts/Koan.ZenGarden.Contracts.csproj
+++ b/src/Koan.ZenGarden.Contracts/Koan.ZenGarden.Contracts.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <PackageValidationBaselineVersion>0.20.1</PackageValidationBaselineVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>Inert client, discovery, connection-intent, and capability contracts for Koan Zen Garden integrations.</Description>

--- a/tests/Koan.Packaging.Tests/PackageTrainBaselinePolicyTests.cs
+++ b/tests/Koan.Packaging.Tests/PackageTrainBaselinePolicyTests.cs
@@ -10,45 +10,31 @@ public sealed class PackageTrainBaselinePolicyTests
     private const string AssemblyProject = "src/Koan.Core/Koan.Core.csproj";
 
     [Fact]
-    public async Task BootstrapReleaseKeepsTheHistoricalPackageBaseline()
+    public async Task AssemblyPackagesUseTheSharedTrainBaseline()
     {
-        var properties = await EvaluateAsync("1.0.0");
-
-        Assert.Equal("", properties.GetProperty("KoanTrainBaselineVersion").GetString());
-        Assert.Equal("0.20.4", properties.GetProperty("PackageValidationBaselineVersion").GetString());
-        Assert.Equal("true", properties.GetProperty("EnablePackageValidation").GetString());
-    }
-
-    [Theory]
-    [InlineData(AssemblyProject)]
-    [InlineData("templates/Sylin.Koan.Templates.csproj")]
-    public async Task LaterPublicReleaseFailsWithoutTheCentralTrainBaseline(string projectPath)
-    {
-        var result = await new ProcessRunner().RunAsync(
-            "dotnet",
-            Arguments("1.0.1", projectPath: projectPath),
-            FindKoanRoot(),
-            CancellationToken.None);
-
-        Assert.NotEqual(0, result.ExitCode);
-        Assert.Contains("requires KoanTrainBaselineVersion", result.StandardError + result.StandardOutput, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public async Task LaterPublicReleaseUsesTheCentralTrainBaseline()
-    {
-        var properties = await EvaluateAsync("1.0.1", "1.0.0");
+        var properties = await EvaluateAsync("1.0.1");
 
         Assert.Equal("1.0.0", properties.GetProperty("KoanTrainBaselineVersion").GetString());
         Assert.Equal("1.0.0", properties.GetProperty("PackageValidationBaselineVersion").GetString());
         Assert.Equal("true", properties.GetProperty("EnablePackageValidation").GetString());
     }
 
-    private static async Task<JsonElement> EvaluateAsync(string packageVersion, string? trainBaseline = null)
+    [Fact]
+    public async Task ContentOnlyPackagesDoNotReceiveAnAssemblyBaseline()
+    {
+        var properties = await EvaluateAsync("1.0.1", "templates/Sylin.Koan.Templates.csproj");
+
+        Assert.Equal("1.0.0", properties.GetProperty("KoanTrainBaselineVersion").GetString());
+        Assert.Equal("", properties.GetProperty("PackageValidationBaselineVersion").GetString());
+    }
+
+    private static async Task<JsonElement> EvaluateAsync(
+        string packageVersion,
+        string projectPath = AssemblyProject)
     {
         var output = await new ProcessRunner().RequireAsync(
             "dotnet",
-            Arguments(packageVersion, trainBaseline, readProperties: true),
+            Arguments(packageVersion, readProperties: true, projectPath: projectPath),
             FindKoanRoot(),
             CancellationToken.None);
         using var document = JsonDocument.Parse(output);
@@ -57,7 +43,6 @@ public sealed class PackageTrainBaselinePolicyTests
 
     private static IReadOnlyList<string> Arguments(
         string packageVersion,
-        string? trainBaseline = null,
         bool readProperties = false,
         string projectPath = AssemblyProject)
     {
@@ -70,10 +55,6 @@ public sealed class PackageTrainBaselinePolicyTests
             "-property:PublicRelease=true",
             $"-property:PackageVersion={packageVersion}"
         };
-        if (trainBaseline is not null)
-        {
-            arguments.Add($"-property:KoanTrainBaselineVersion={trainBaseline}");
-        }
         if (readProperties)
         {
             arguments.Add("-getProperty:KoanTrainBaselineVersion,PackageValidationBaselineVersion,EnablePackageValidation");


### PR DESCRIPTION
Completes the post-release transition promised by ARCH-0124: sets one central 1.0.0 package-validation baseline, removes 67 project-local declarations and nine root exceptions, and updates the focused policy tests/docs. Validation: 2 focused policy tests, clean Release build, and all 94 packages packed successfully against the public 1.0.0 train using an isolated NuGet.org cache.