### PR TITLE
Environment posture is a named decision, not a boolean read

### DIFF
--- a/.codex/skills/explore/SKILL.md
+++ b/.codex/skills/explore/SKILL.md
@@ -13,6 +13,10 @@ Do not write production code until all steps are done.
 - Entity-first data access: prefer `Entity<T>` statics; avoid repositories and `Data<TEntity,TKey>` unless no static exists.
 - Controllers-only HTTP: no inline endpoints (`MapGet`/`MapPost`/etc) unless an ADR explicitly allows it.
 - No magic literals: stable identifiers go in `Infrastructure/Constants`; tunables are typed `*Options`.
+- Environment posture: gate capabilities through `KoanEnv.Gate` — a `KoanMagic` for a convenience that is
+  risky only in production (Production is the gate, so Staging/Test/CI still run it), `DevelopmentOnly`
+  for a surface nothing may unlock — never a raw `IsDevelopment()`/`IsProduction()`. Diagnostics may
+  read directly; a guard spec enumerates every exception (ARCH-0128).
 - Docs posture: instruction-first (no tutorials); update ADRs and TOCs when behavior/policy changes.
 - Per-project docs: `README.md` + `TECHNICAL.md` at project roots for reusable modules.
 - Large data paths: use capability-qualified streaming or explicit paging. InMemory, JSON, and Redis

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,11 @@ public sealed class TodosController : EntityController<Todo>;
 - Prefer standard .NET hosting, DI, options, health, assembly, MSBuild, and NuGet concepts before
   creating a Koan-specific part.
 - Complexity centralized at one owner is acceptable; the same complexity distributed across consumers is not.
+- Environment posture is a named decision, never a raw `IsDevelopment()` / `IsProduction()` read.
+  A convenience that is risky only in production declares a `KoanMagic` and passes it to `KoanEnv.Gate`
+  (Production is the gate, so it still runs in Staging, Test, and CI); a surface that must not exist
+  outside development uses `KoanEnv.Gate.DevelopmentOnly`, which nothing unlocks. Diagnostics may read
+  the environment directly. A guard spec enumerates every exception — see ARCH-0128.
 
 ## Application patterns
 

--- a/docs/decisions/ARCH-0128-environment-posture-is-a-named-decision.md
+++ b/docs/decisions/ARCH-0128-environment-posture-is-a-named-decision.md
@@ -104,6 +104,18 @@ The MCP transports' plaintext warning (`IsProduction && !InContainer && !IsHttps
 no TLS-terminating proxy in front") stays a transport-local heuristic. It is one concept in one pillar
 and does not earn a framework name.
 
+### Enforcement
+
+The rule was already written when the drift happened, because a direct `IsDevelopment()` read compiles,
+passes review, and looks exactly like correct code. Prose alone does not hold it, so the law is
+structural: `EnvironmentGateConformanceSpec` scans `src/` and enumerates every direct environment read
+with the reason it is allowed. A new one fails the build with a message that names the three gates and
+asks which decision the author is making. Removing one also fails, so the list cannot accumulate
+entries that stopped being true.
+
+The allowlist is keyed by file **and count**, so a new gate added inside an already-allowed file is
+caught too. `KoanEnv.cs` and `KoanEnvGate.cs` are excluded as the mechanism itself.
+
 ## Consequences
 
 Behavior changes, both corrections:
@@ -128,6 +140,11 @@ uninitialized (an unset environment name is neither Development nor Production).
 - `tests/Suites/Core/Koan.Core.Tests/Hosting/EnvironmentGateSpec.cs` — 10 specs pinning the law,
   including that every environment below Production runs the convenience and that a refusal names all
   four of capability, risk, remedy, and flag
+- `tests/Suites/Core/Koan.Core.Tests/Hosting/EnvironmentGateConformanceSpec.cs` — the structural
+  guard, mutation-verified in both directions: an injected bespoke gate in a new file and a second
+  read inside an allowed file each fail with the teaching message
+- The law is stated once and routed to, not restated: `CLAUDE.md` architectural laws and
+  `.codex/skills/explore/SKILL.md` global constraints each carry one line pointing here
 - Full solution builds with 0 warnings; Core (349), Classification (60), Identity (90), MCP
   Conformance (84), MCP Explorer (16), Auth Server (50), Web Admin (13), OpenAPI (12), Tenancy Web
   (13), Data Core (474), Sqlite (48), Relational (18) all green

--- a/docs/decisions/ARCH-0128-environment-posture-is-a-named-decision.md
+++ b/docs/decisions/ARCH-0128-environment-posture-is-a-named-decision.md
@@ -1,0 +1,133 @@
+---
+id: ARCH-0128
+slug: environment-posture-is-a-named-decision
+domain: Architecture
+status: Accepted
+date: 2026-08-19
+title: Environment posture is a named decision, not a boolean read
+related:
+  - DATA-0046
+  - SEC-0001
+  - MESS-0026
+---
+
+# ARCH-0128: Environment posture is a named decision, not a boolean read
+
+## Outcome
+
+A capability may not decide whether it composes by reading `IsDevelopment()` or `IsProduction()`
+directly. It states which **named decision** it is making, and `KoanEnv.Gate` applies that decision's
+law:
+
+| Gate | The question it answers | Unlockable in Production? |
+| --- | --- | --- |
+| `KoanEnv.Gate.Enforce` / `Allows` / `Announce` (a `KoanMagic`) | May this convenience run automatically? | Yes — the capability's own option, or `Koan:AllowMagicInProduction` |
+| `KoanEnv.Gate.DevelopmentOnly` | May this surface exist at all? | **No.** Nothing unlocks it |
+| `KoanEnv.Gate.LooksDeployed` | What should the unconfigured default be? | n/a — a default, never an authorization |
+
+Reading `KoanEnv.IsDevelopment` / `IsProduction` remains correct for **diagnostics**: log verbosity,
+startup banners, how much detail a health payload carries. Those are descriptions of the environment,
+not decisions about capability.
+
+## Context
+
+The environment booleans are honest facts, and nothing was wrong with them. What was missing was
+vocabulary. Every call site that needed to gate a capability re-derived, from scratch, *which* fact
+answered the question — and the answers drifted apart. A survey found 43 such derivations across 33
+files, in at least four mutually inconsistent spellings.
+
+Three were live defects:
+
+1. **Staging was treated as Production, inconsistently.** Auto-DDL gated on `!IsProduction`, so it ran
+   in Staging. AI endpoint auto-discovery gated on `IsDevelopment`, so it did not. Nothing articulated
+   why the two should differ; they differed because two authors picked different booleans.
+
+2. **A documented escape hatch that no call site consulted.** DATA-0046 §Implementation states that in
+   Production, "either `KoanEnv.AllowMagicInProduction` or `AllowProductionDdl` must be true." All
+   three relational DDL gates checked only `AllowProductionDdl`. The framework-wide flag was
+   documented, configurable, reported in the boot snapshot, and inert.
+
+3. **A safety rail shipped as a functionality block.** An earlier Classification gate refused local key
+   custody outside `IsDevelopment()`, which broke Test, Staging, and CI — environments where the
+   built-in provider is exactly right. The law is that *Production* is the gate.
+
+The failure mode is not carelessness. It is that "is this Development?" and "may this capability
+compose?" are different questions that happen to share a datatype, so a wrong answer type-checks.
+
+A fourth family made the same mistake in the opposite direction, and matters more. Development-only
+surfaces — the admin console, the dev token endpoint, seeded credentials, the test auth provider —
+must be **absent** outside Development, and SEC-0001 §4.2 requires that gate stay decoupled from
+`AllowMagicInProduction`. Folding those into one universal "environment gate" would have made a
+convenience flag into an authentication bypass. That is precisely why this ADR names two gates rather
+than one, and why they do not share a parameter.
+
+## Decision
+
+**One law per named decision, stated once.**
+
+`KoanMagic` describes a convenience as a value: what it does, what the risk is in Production, and what
+the operator should do instead. Those fields are required because a refusal missing any of them is an
+outage without a remedy. `KoanEnv.Gate` turns that description into a verdict:
+
+| Environment | Verdict | Behavior |
+| --- | --- | --- |
+| Development | `Allowed` | Runs silently — the ordinary inner loop |
+| Staging, Test, CI, unset | `AllowedWithNotice` | Runs, and warns |
+| Production **with** consent | `AllowedByConsent` | Runs, and warns |
+| Production **without** consent | `Refused` | Refuses, naming capability, risk, remedy, and the flag |
+
+Consent is the capability's own option **or** `Koan:AllowMagicInProduction`. Either alone suffices:
+requiring both would make the framework-wide flag useless, and requiring neither would make Production
+indistinguishable from Development.
+
+`DevelopmentOnly` takes no consent parameter and reads no flag. The absence of an override is the
+feature; a surface that wants one belongs behind a `KoanMagic` instead, which is a design question to
+answer deliberately rather than a call-site workaround.
+
+`LooksDeployed` (Production **or** in a container) picks defaults only. Container detection is
+evidence, not proof, so it must never decide whether a request is authorized — only what an
+unconfigured setting should be when nobody said.
+
+### Deliberate exceptions
+
+Three sites read the environment directly and are annotated in place, so the next reader can see they
+were considered rather than missed:
+
+- **`DataAxisPreflight`** — a confirmed cross-tenant read is not a convenience, so nothing may unlock
+  it. Routing it through `KoanMagic` would let `AllowMagicInProduction` unlock a data-isolation leak.
+- **`IssuerKeyGuard`** — guards Production *and* Staging (both issue tokens real clients hold), with
+  its own dedicated acknowledgement rather than the shared flag.
+- **`IssuerKeyRotationService`** — a background schedule with no work to do in Development. No surface
+  is being gated, so no gate applies.
+
+The MCP transports' plaintext warning (`IsProduction && !InContainer && !IsHttps` — "production with
+no TLS-terminating proxy in front") stays a transport-local heuristic. It is one concept in one pillar
+and does not earn a framework name.
+
+## Consequences
+
+Behavior changes, both corrections:
+
+- **Auto-DDL now honors `Koan:AllowMagicInProduction`**, as DATA-0046 always specified. Setting the
+  flag in Production previously did nothing for schema creation.
+- **AI endpoint auto-discovery now runs in Staging, Test, and CI**, with a warning, instead of being
+  silently off. This matches MESS-0026's stated policy ("off by default in Production, on in other
+  environments") and removes the unexplained divergence from DDL. Production behavior is unchanged.
+
+Everything else is a refactor: all 43 decision points now say which decision they are making, and a reader
+can answer "can this be turned on in production?" by reading the method name.
+
+The gates take an optional `IHostEnvironment`. Passing the injected one keeps the decision testable and
+scoped to the host; omitting it falls back to the process snapshot, which is fail-closed when
+uninitialized (an unset environment name is neither Development nor Production).
+
+## Evidence
+
+- `KoanEnv.Gate` and `KoanMagic` — `src/Koan.Core/KoanEnvGate.cs`
+- `RelationalDdlGate` — one description of auto-DDL shared by three adapters
+- `tests/Suites/Core/Koan.Core.Tests/Hosting/EnvironmentGateSpec.cs` — 10 specs pinning the law,
+  including that every environment below Production runs the convenience and that a refusal names all
+  four of capability, risk, remedy, and flag
+- Full solution builds with 0 warnings; Core (349), Classification (60), Identity (90), MCP
+  Conformance (84), MCP Explorer (16), Auth Server (50), Web Admin (13), OpenAPI (12), Tenancy Web
+  (13), Data Core (474), Sqlite (48), Relational (18) all green

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -69,6 +69,7 @@ Storage, variant routing, transform pipeline, and the recipe-based rendering sur
 | ARCH-0125 | [Each package owns its version on one shared compatibility train](ARCH-0125-per-project-package-versions.md) | Accepted | Project-local version ownership, a per-package version manifest, and publication that skips unchanged packages |
 | ARCH-0126 | [A process-global resource is owned by a process-derived fact](ARCH-0126-process-global-resource-ownership.md) | Accepted | Standard output ownership resolved from the process before composition; capabilities observe it rather than claim it |
 | ARCH-0127 | [Connector fleet strategy — capability without infrastructure](ARCH-0127-connector-fleet-strategy.md) | Accepted | Connectors ranked by capability added per unit of infrastructure imposed; a connector without an existing conformance oracle is not delegable |
+| ARCH-0128 | [Environment posture is a named decision, not a boolean read](ARCH-0128-environment-posture-is-a-named-decision.md) | Accepted | Capabilities gate on a named decision (`KoanEnv.Gate`), not on `IsDevelopment`/`IsProduction`; Production is the gate and consent is the unlock, except where nothing may unlock |
 
 ## Authoring Principles
 

--- a/docs/reference/core/index.md
+++ b/docs/reference/core/index.md
@@ -66,6 +66,47 @@ Contracts assembly; referencing contracts must not activate functionality.
 and `ReportComposition` project resolved facts; applications do not call them. Recurring or pokable
 work belongs to the background-service or Jobs contracts, not `Start`.
 
+## Environment posture
+
+A module that gates behavior on the environment names the decision it is making. `KoanEnv.IsDevelopment`
+and `IsProduction` stay available and are the right read for diagnostics — log level, banner detail —
+but they are the wrong tool for deciding whether a capability composes, because that has a law.
+
+**A convenience that is safe everywhere but risky in Production** — schema auto-creation, endpoint
+auto-discovery, a local key file — declares itself and lets the gate apply the law:
+
+```csharp
+KoanEnv.Gate.Enforce(new KoanMagic(
+    Capability: "automatic schema creation",
+    Risk: "Koan issues CREATE and ALTER against whatever database the connection string resolves to.",
+    Remedy: "provision the schema out of band, or set AllowProductionDdl on the source",
+    Consent: options.AllowProductionDdl), environment, logger);
+```
+
+Production is the gate, not Development. The capability runs from a bare reference in Development,
+Staging, Test, and CI — warning outside Development — and in Production asks for consent rather than
+disappearing. Consent is the capability's own option **or** `Koan:AllowMagicInProduction`. A refusal
+names the capability, the risk, the remedy, and the flag, so an operator can act on it without reading
+source. Use `Gate.Announce` instead of `Enforce` when skipping is a coherent outcome and refusing the
+host would be wrong.
+
+**A surface that must not exist outside Development** — an admin console, a dev token endpoint, seeded
+credentials — uses the other gate:
+
+```csharp
+if (!KoanEnv.Gate.DevelopmentOnly(environment)) return;
+```
+
+It takes no consent parameter and no flag unlocks it, deliberately: a convenience flag that also
+switched on seeded credentials would be an authentication bypass. Whatever it guards should be absent
+from the production service graph, not merely unreachable.
+
+**An unconfigured default** uses `KoanEnv.Gate.LooksDeployed(environment)` — Production, or anything in
+a container. It picks what a setting should be when nobody said; it is a heuristic and never decides
+whether a request is authorized.
+
+See [ARCH-0128](../../decisions/ARCH-0128-environment-posture-is-a-named-decision.md).
+
 ## Composition and provider decisions
 
 Core compiles structural contributions once per host shape. Pillars then own semantic policy and

--- a/src/Connectors/AI/LMStudio/Initialization/LMStudioAdapterContributor.cs
+++ b/src/Connectors/AI/LMStudio/Initialization/LMStudioAdapterContributor.cs
@@ -158,8 +158,16 @@ internal sealed class LMStudioAdapterContributor : IAiProviderActivator
             ["Embedding"] = new() { Model = model ?? string.Empty }
         };
 
+    // Production is the gate, not Development. This used to read IsDevelopment, which silently refused
+    // discovery in Staging, Test, and CI -- environments where probing a local endpoint is exactly as
+    // reasonable as it is on a laptop, and where MESS-0026 says discovery should be on.
     private static bool ShouldDiscover(AiOptions options) =>
-        options.AutoDiscoveryEnabled && (KoanEnv.IsDevelopment || options.AllowDiscoveryInNonDev);
+        options.AutoDiscoveryEnabled && KoanEnv.Gate.Allows(new KoanMagic(
+            Capability: "LM Studio endpoint auto-discovery",
+            Risk: "Koan probes well-known local addresses and adopts whatever answers, which in production "
+                + "means the model serving your users is whatever happened to be listening.",
+            Remedy: "configure the endpoint explicitly, or set AllowDiscoveryInNonDev to accept discovery there",
+            Consent: options.AllowDiscoveryInNonDev));
 
     private static Uri? FirstEndpoint(AiSourceDefinition? source)
     {

--- a/src/Connectors/AI/Ollama/Initialization/OllamaAdapterContributor.cs
+++ b/src/Connectors/AI/Ollama/Initialization/OllamaAdapterContributor.cs
@@ -156,8 +156,16 @@ internal sealed class OllamaAdapterContributor : IAiProviderActivator
             ["Embedding"] = new() { Model = model }
         };
 
+    // Production is the gate, not Development. This used to read IsDevelopment, which silently refused
+    // discovery in Staging, Test, and CI -- environments where probing a local endpoint is exactly as
+    // reasonable as it is on a laptop, and where MESS-0026 says discovery should be on.
     private static bool ShouldDiscover(AiOptions options) =>
-        options.AutoDiscoveryEnabled && (KoanEnv.IsDevelopment || options.AllowDiscoveryInNonDev);
+        options.AutoDiscoveryEnabled && KoanEnv.Gate.Allows(new KoanMagic(
+            Capability: "Ollama endpoint auto-discovery",
+            Risk: "Koan probes well-known local addresses and adopts whatever answers, which in production "
+                + "means the model serving your users is whatever happened to be listening.",
+            Remedy: "configure the endpoint explicitly, or set AllowDiscoveryInNonDev to accept discovery there",
+            Consent: options.AllowDiscoveryInNonDev));
 
     private static Uri? FirstEndpoint(AiSourceDefinition? source)
     {

--- a/src/Connectors/Data/MySql/Runtime/MySqlSchema.cs
+++ b/src/Connectors/Data/MySql/Runtime/MySqlSchema.cs
@@ -215,7 +215,7 @@ internal static class MySqlSchema
         options.SourcePlan.StorageLifecycle == StorageLifecycle.Managed &&
         options.SourcePlan.Access == DataSourceAccess.ReadWrite &&
         options.DdlPolicy == RelationalDdlPolicy.AutoCreate &&
-        (!Koan.Core.KoanEnv.IsProduction || options.AllowProductionDdl);
+        RelationalDdlGate.Allowed(options.AllowProductionDdl);
 
     private static SchemaMismatchException Mismatch<TEntity, TKey>(
         MySqlEntityPlan<TEntity, TKey> plan,

--- a/src/Connectors/Data/Sqlite/Runtime/SqliteSchema.cs
+++ b/src/Connectors/Data/Sqlite/Runtime/SqliteSchema.cs
@@ -18,9 +18,9 @@ internal static class SqliteSchema
         if (route.Options.DdlPolicy != RelationalDdlPolicy.AutoCreate)
             throw new InvalidOperationException(
                 $"SQLite cannot provision '{plan.Table}' because DdlPolicy is {route.Options.DdlPolicy}.");
-        if (Koan.Core.KoanEnv.IsProduction && !route.Options.AllowProductionDdl)
+        if (!RelationalDdlGate.Allowed(route.Options.AllowProductionDdl))
             throw new InvalidOperationException(
-                $"SQLite production DDL is disabled for '{plan.Table}'. Enable it only for a Koan-owned store.");
+                $"SQLite cannot provision '{plan.Table}'. {RelationalDdlGate.Refusal}");
 
         connections.PrepareManaged(route.ConnectionString);
         await using var connection = connections.Create(route.ConnectionString, route.Source);

--- a/src/Connectors/Web/Auth/Test/Initialization/TestAuthModule.cs
+++ b/src/Connectors/Web/Auth/Test/Initialization/TestAuthModule.cs
@@ -43,7 +43,7 @@ public sealed class TestAuthModule : KoanModule
             cfg,
             $"{TestProviderOptions.SectionPath}:{nameof(TestProviderOptions.Enabled)}",
             false);
-        var active = enabledOption.Value || env.IsDevelopment();
+        var active = enabledOption.Value || KoanEnv.Gate.DevelopmentOnly(env);
 
         module.PublishConfigValue(
             TestProviderItems.Enabled,

--- a/src/Connectors/Web/Auth/Test/Options/TestProviderOptions.cs
+++ b/src/Connectors/Web/Auth/Test/Options/TestProviderOptions.cs
@@ -1,3 +1,4 @@
+using Koan.Core;
 using Microsoft.Extensions.Hosting;
 
 namespace Koan.Web.Auth.Connector.Test.Options;
@@ -40,6 +41,6 @@ public sealed class TestProviderOptions
     /// attribute-routed endpoints remain fail-closed outside Development unless explicitly enabled.
     /// </summary>
     public bool IsActive(IHostEnvironment? env)
-        => Enabled || (env?.IsDevelopment() ?? false);
+        => Enabled || KoanEnv.Gate.DevelopmentOnly(env);
 }
 

--- a/src/Koan.Classification/Initialization/ClassificationModule.cs
+++ b/src/Koan.Classification/Initialization/ClassificationModule.cs
@@ -37,28 +37,18 @@ public sealed class ClassificationModule : KoanModule
         // the host. Either is fine to develop against and neither is a production key service.
         var localCustody = provider is EphemeralClassificationKeyProvider or LocalFileClassificationKeyProvider;
 
-        // Production is the gate, not Development. Koan's convention is that a capability works from a
-        // bare reference everywhere and asks for explicit consent only in Production -- the same shape
-        // as AllowProductionDdl, and honoring the framework-wide Koan:AllowMagicInProduction escape
-        // hatch. Gating on !IsDevelopment() instead turned a production safety rail into a functionality
-        // block that broke Test and Staging, including CI.
-        if (localCustody && environment.IsProduction() && !KoanEnv.AllowMagicInProduction)
-            throw new InvalidOperationException(
-                $"Koan Classification refuses a local-custody key in environment '{environment.EnvironmentName}'. " +
-                $"The built-in providers keep key material beside the data and never rotate it, which is a " +
-                $"development posture. Register an {nameof(IClassificationKeyProvider)} backed by your key service " +
-                $"before AddKoan() completes composition, or set Koan:AllowMagicInProduction to accept local custody.");
-
-        // Loud outside Development, because an ephemeral key is a real data-loss boundary the moment
-        // anything persists across a restart -- but it is a warning to act on, not a wall.
-        if (localCustody && !environment.IsDevelopment())
-            logger?.LogWarning(
-                "Classification is using local key custody in environment '{Environment}' ({Provider}). Key material " +
-                "sits beside the data it protects and is never rotated. Register an {Contract} backed by your key " +
-                "service before this reaches production.",
-                environment.EnvironmentName,
-                provider.GetType().Name,
-                nameof(IClassificationKeyProvider));
+        // The shared law: refuses in Production without consent, warns in Staging/Test/CI, silent in
+        // Development. Spelling that out by hand cost a bug already -- an earlier version of this gate
+        // read !IsDevelopment(), which turned a production safety rail into a functionality block that
+        // broke Test, Staging, and CI.
+        if (localCustody)
+            KoanEnv.Gate.Enforce(new KoanMagic(
+                Capability: "a local-custody key",
+                Risk: "the built-in providers keep key material beside the data it protects and never rotate it, "
+                    + "so anyone who can read the database can read the keyring.",
+                Remedy: $"register an {nameof(IClassificationKeyProvider)} backed by your key service before "
+                    + "AddKoan() completes composition"),
+                environment, logger);
 
         // Name the custody, not just the type. "Which file holds my keys?" is the first question anyone asks
         // the moment classified data matters, and it should not require reading the source to answer.

--- a/src/Koan.Core/KoanEnv.cs
+++ b/src/Koan.Core/KoanEnv.cs
@@ -11,7 +11,7 @@ using System.Reflection;
 namespace Koan.Core;
 
 // Single, immutable runtime snapshot available statically
-public static class KoanEnv
+public static partial class KoanEnv
 {
     /// <summary>
     /// Dumps the current environment snapshot using proper logging.

--- a/src/Koan.Core/KoanEnvGate.cs
+++ b/src/Koan.Core/KoanEnvGate.cs
@@ -1,0 +1,234 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Koan.Core;
+
+/// <summary>
+/// Where an automatic convenience stands in the current environment. Produced by
+/// <see cref="KoanEnv.Gate.Evaluate"/>; every value except <see cref="Refused"/> means the convenience runs.
+/// </summary>
+public enum MagicVerdict
+{
+    /// <summary>Development. The convenience runs silently — this is the ordinary inner loop.</summary>
+    Allowed,
+
+    /// <summary>
+    /// Neither Development nor Production (Staging, Test, CI, or unset). The convenience still runs, because
+    /// refusing here breaks CI and staging for no safety gain, but it announces itself so nobody discovers the
+    /// posture by accident later.
+    /// </summary>
+    AllowedWithNotice,
+
+    /// <summary>Production, with explicit consent. The convenience runs and says so at warning level.</summary>
+    AllowedByConsent,
+
+    /// <summary>Production without consent. The convenience refuses.</summary>
+    Refused
+}
+
+/// <summary>
+/// One automatic convenience, described well enough that Koan can explain itself when it refuses.
+///
+/// <para>Every field exists because a refusal without it is useless. <paramref name="Capability"/> names what
+/// stopped, <paramref name="Risk"/> says why Production is different, and <paramref name="Remedy"/> tells the
+/// operator what to do instead. Passing vague strings produces a vague error at 3am.</para>
+/// </summary>
+/// <param name="Capability">
+/// What the convenience does, as a noun phrase that completes "Koan refuses ___ in Production" —
+/// e.g. <c>"relational DDL"</c>, <c>"a local-custody key"</c>, <c>"AI provider auto-discovery"</c>.
+/// </param>
+/// <param name="Risk">
+/// One sentence on what could go wrong in Production. This is the half an operator actually needs.
+/// </param>
+/// <param name="Remedy">
+/// The capability-specific way to proceed deliberately — the option to set, or the service to register.
+/// The framework-wide escape hatch is appended automatically; do not restate it here.
+/// </param>
+/// <param name="Consent">
+/// The capability's own opt-in (<c>AllowProductionDdl</c>, <c>AllowDiscoveryInNonDev</c>, …). True means the
+/// application asked for this specific behavior in Production, which is stronger evidence of intent than the
+/// framework-wide flag and is why capabilities keep their own switch.
+/// </param>
+public readonly record struct KoanMagic(string Capability, string Risk, string Remedy, bool Consent = false);
+
+public static partial class KoanEnv
+{
+    /// <summary>
+    /// The single place Koan decides whether a behavior may run in the current environment.
+    ///
+    /// <para><b>Why this exists.</b> <see cref="KoanEnv.IsDevelopment"/> and <see cref="KoanEnv.IsProduction"/>
+    /// are honest facts, and reading them is fine for diagnostics — log verbosity, banners, how much detail a
+    /// health payload carries. They are the wrong tool for deciding whether a <i>capability</i> composes,
+    /// because that decision has a law, and re-deriving the law at each call site is how call sites drift
+    /// apart. Three real drifts came from exactly that: auto-DDL gated on <c>!IsProduction</c> while AI
+    /// discovery gated on <c>IsDevelopment</c> (so Staging silently behaved differently for no stated reason),
+    /// and neither honored <c>Koan:AllowMagicInProduction</c> even though
+    /// <see href="https://github.com/sylin-org/koan-framework/blob/main/docs/decisions/DATA-0046-sqlite-schema-governance-ddl-policy.md">DATA-0046</see>
+    /// says it should.</para>
+    ///
+    /// <para><b>Choosing between the two gates.</b> They are deliberately not the same call, because they are
+    /// not the same decision and one of them must never be unlockable:</para>
+    /// <list type="bullet">
+    ///   <item><description>
+    ///     <see cref="KoanMagic"/> — a convenience that is <i>safe everywhere but risky in Production</i>: schema
+    ///     auto-creation, endpoint auto-discovery, a local key file. It runs by default, and in Production it
+    ///     asks for consent rather than disappearing. Reach for this when the honest sentence is
+    ///     "this is fine until it is production data".
+    ///   </description></item>
+    ///   <item><description>
+    ///     <see cref="DevelopmentOnly"/> — a surface that <i>must not exist</i> outside Development: the admin
+    ///     UI, the dev token endpoint, seeded credentials, the test auth provider. No flag unlocks it, on
+    ///     purpose. Reach for this when the honest sentence is "shipping this would be a vulnerability".
+    ///   </description></item>
+    /// </list>
+    ///
+    /// <para><b>The law a <see cref="KoanMagic"/> gate applies.</b> Production is the gate, not Development. A capability
+    /// works from a bare reference in every environment and asks for explicit consent only in Production —
+    /// consent being either the capability's own option or the framework-wide
+    /// <c>Koan:AllowMagicInProduction</c>. Gating on <c>!IsDevelopment()</c> instead turns a production safety
+    /// rail into a functionality block that breaks Test, Staging, and CI.</para>
+    ///
+    /// <example>
+    /// The usual shape — refuse in Production, warn outside Development, silent in Development:
+    /// <code>
+    /// KoanEnv.Gate.Enforce(new KoanMagic(
+    ///     Capability: "relational DDL",
+    ///     Risk: "schema changes are applied directly to whatever database the connection string points at",
+    ///     Remedy: "provision the schema out of band, or set AllowProductionDdl on the source",
+    ///     Consent: policy.AllowProductionDdl), environment, logger);
+    /// </code>
+    /// When refusing would be wrong and skipping is correct, use <see cref="Announce"/>, which never throws.
+    /// </example>
+    /// </summary>
+    public static class Gate
+    {
+        /// <summary>
+        /// Decide where <paramref name="magic"/> stands, without acting on it. Prefer <see cref="Enforce"/> or
+        /// <see cref="Announce"/>, which also produce the explanation; reach for this when the verdict feeds a
+        /// larger policy decision the caller reports itself.
+        /// </summary>
+        /// <param name="magic">The convenience being considered, and the capability's own consent flag.</param>
+        /// <param name="environment">
+        /// The host environment, when the caller has one injected. Passing it keeps the decision testable and
+        /// scoped to this host. Omit it only before DI exists, where the static snapshot is the only source.
+        /// </param>
+        public static MagicVerdict Evaluate(in KoanMagic magic, IHostEnvironment? environment = null)
+        {
+            var production = environment?.IsProduction() ?? IsProduction;
+            if (!production)
+            {
+                var development = environment?.IsDevelopment() ?? IsDevelopment;
+                return development ? MagicVerdict.Allowed : MagicVerdict.AllowedWithNotice;
+            }
+
+            // The framework-wide flag is a second key, not a replacement for the capability's own. Either is
+            // consent; requiring both would make the global flag useless, and requiring neither would make
+            // Production indistinguishable from Development.
+            return magic.Consent || AllowMagicInProduction
+                ? MagicVerdict.AllowedByConsent
+                : MagicVerdict.Refused;
+        }
+
+        /// <summary>Whether <paramref name="magic"/> may run here. The bool form of <see cref="Evaluate"/>.</summary>
+        public static bool Allows(in KoanMagic magic, IHostEnvironment? environment = null)
+            => Evaluate(magic, environment) != MagicVerdict.Refused;
+
+        /// <summary>
+        /// Run the convenience or refuse the host. Throws <see cref="InvalidOperationException"/> in Production
+        /// without consent, warns when the posture deserves saying out loud, and stays silent in Development.
+        ///
+        /// <para>Use this when proceeding without the convenience would leave the application broken or
+        /// silently wrong — an entity with no table, a key nobody can decrypt with. Refusing at boot beats
+        /// failing on the first request.</para>
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Production, and neither consent was given.</exception>
+        public static void Enforce(in KoanMagic magic, IHostEnvironment? environment = null, ILogger? logger = null)
+        {
+            var verdict = Evaluate(magic, environment);
+            if (verdict == MagicVerdict.Refused) throw new InvalidOperationException(Refusal(magic));
+            Notify(magic, verdict, environment, logger);
+        }
+
+        /// <summary>
+        /// Report whether the convenience may run, and say so when the posture deserves it. Never throws.
+        ///
+        /// <para>Use this when skipping is a coherent outcome — discovery that finds nothing, a probe that
+        /// stays off. A refusal here is not an error, so it is logged at information level: the operator asked
+        /// for Production, and Production behaving like Production is the expected result.</para>
+        /// </summary>
+        /// <returns><see langword="true"/> when the caller should proceed.</returns>
+        public static bool Announce(in KoanMagic magic, ILogger? logger = null, IHostEnvironment? environment = null)
+        {
+            var verdict = Evaluate(magic, environment);
+            if (verdict == MagicVerdict.Refused)
+            {
+                logger?.LogInformation(
+                    "Koan skipped {Capability} in Production. {Risk} To enable it: {Remedy}, or set {Flag}=true.",
+                    magic.Capability, magic.Risk, magic.Remedy, Infrastructure.Constants.Configuration.Koan.AllowMagicInProduction);
+                return false;
+            }
+
+            Notify(magic, verdict, environment, logger);
+            return true;
+        }
+
+        /// <summary>
+        /// Whether development-only surfaces may exist in this host.
+        ///
+        /// <para><b>No flag unlocks this, and that is the point.</b> It is deliberately decoupled from
+        /// <c>Koan:AllowMagicInProduction</c> per
+        /// <see href="https://github.com/sylin-org/koan-framework/blob/main/docs/decisions/SEC-0001-fleet-identity-and-trust-fabric.md">SEC-0001</see>:
+        /// a convenience flag that also switched on the admin UI, seeded credentials, or the dev token endpoint
+        /// would turn one careless environment variable into an authentication bypass. Whatever this gate
+        /// guards should be absent from the production DI graph entirely, not merely unreachable.</para>
+        ///
+        /// <para>If you find yourself wanting an override, the surface belongs behind a <see cref="KoanMagic"/> gate
+        /// instead — which is a real design question worth answering deliberately, not a call-site workaround.</para>
+        /// </summary>
+        /// <param name="environment">The injected host environment; omit only before DI exists.</param>
+        public static bool DevelopmentOnly(IHostEnvironment? environment = null)
+            => environment?.IsDevelopment() ?? IsDevelopment;
+
+        /// <summary>
+        /// Whether this host looks like a real deployment rather than someone's machine — Production, or
+        /// anything running in a container.
+        ///
+        /// <para>Use it to pick a <i>default</i> for a setting the application can still override: require
+        /// authentication unless told otherwise, leave an explorer UI off unless asked for. A developer running
+        /// in Docker Compose gets the cautious default, which is the right way round — the cost is one explicit
+        /// setting, and the alternative is an unauthenticated endpoint nobody meant to publish.</para>
+        ///
+        /// <para><b>This is a heuristic, not a security boundary.</b> Container detection is evidence, not
+        /// proof, so never let it decide whether a request is authorized — only what the unconfigured default
+        /// should be. Anything that must hold under attack belongs behind <see cref="DevelopmentOnly"/> or an
+        /// explicit policy.</para>
+        /// </summary>
+        /// <param name="environment">The injected host environment; omit only before DI exists.</param>
+        public static bool LooksDeployed(IHostEnvironment? environment = null)
+            => (environment?.IsProduction() ?? IsProduction) || InContainer;
+
+        private static string Refusal(in KoanMagic magic)
+            => $"Koan refuses {magic.Capability} in Production. {magic.Risk} " +
+               $"To allow it: {magic.Remedy}, or set {Infrastructure.Constants.Configuration.Koan.AllowMagicInProduction}=true " +
+               $"to accept this class of risk framework-wide.";
+
+        private static void Notify(in KoanMagic magic, MagicVerdict verdict, IHostEnvironment? environment, ILogger? logger)
+        {
+            if (verdict == MagicVerdict.Allowed || logger is null) return;
+
+            var environmentName = environment?.EnvironmentName ?? EnvironmentName;
+            if (verdict == MagicVerdict.AllowedByConsent)
+            {
+                logger.LogWarning(
+                    "Koan is running {Capability} in Production by explicit consent. {Risk}",
+                    magic.Capability, magic.Risk);
+                return;
+            }
+
+            logger.LogWarning(
+                "Koan is running {Capability} in environment '{Environment}'. {Risk} " +
+                "This is allowed outside Production; {Remedy} before this reaches it.",
+                magic.Capability, environmentName, magic.Risk, magic.Remedy);
+        }
+    }
+}

--- a/src/Koan.Data.Core/Axes/DataAxisPreflight.cs
+++ b/src/Koan.Data.Core/Axes/DataAxisPreflight.cs
@@ -48,6 +48,9 @@ public static class DataAxisPreflight
         var leaks = DetectLeaks(services);
         if (leaks.Count == 0) return;
 
+        // Deliberately NOT KoanEnv.Gate: that gate lets Koan:AllowMagicInProduction unlock a convenience, and a
+        // confirmed cross-tenant read is not a convenience. Nothing may unlock this one, so it reads the
+        // environment directly.
         var refuses = environment.IsProduction();
         var message = Format(leaks, refuses);
         if (refuses)

--- a/src/Koan.Data.Relational/Orchestration/RelationalDdlGate.cs
+++ b/src/Koan.Data.Relational/Orchestration/RelationalDdlGate.cs
@@ -1,0 +1,37 @@
+using Koan.Core;
+
+namespace Koan.Data.Relational.Orchestration;
+
+/// <summary>
+/// Automatic schema creation, described once for every relational adapter.
+///
+/// <para>Three adapters used to spell this gate three ways, and none of them honored
+/// <c>Koan:AllowMagicInProduction</c> even though DATA-0046 says auto-DDL is exactly what that flag governs.
+/// The law now lives in <see cref="KoanEnv.Gate"/>; this type only supplies the words, so a Postgres refusal
+/// and a SQLite refusal say the same thing about the same risk.</para>
+///
+/// <para>Callers keep their own message. The gate decides <i>whether</i>, the adapter says <i>which table</i> —
+/// a refusal that cannot name the object it refused is not much of a refusal.</para>
+/// </summary>
+public static class RelationalDdlGate
+{
+    /// <summary>Auto-DDL as a production risk. <paramref name="consent"/> is the source's <c>AllowProductionDdl</c>.</summary>
+    public static KoanMagic Magic(bool consent) => new(
+        Capability: "automatic schema creation",
+        Risk: "Koan issues CREATE and ALTER against whatever database the connection string resolves to, "
+            + "which in production is live data.",
+        Remedy: "provision the schema out of band and set DdlPolicy to Validate, or set AllowProductionDdl "
+            + "on the source to accept automatic DDL there",
+        Consent: consent);
+
+    /// <summary>Whether auto-DDL may run here, given the source's own <c>AllowProductionDdl</c> setting.</summary>
+    public static bool Allowed(bool consent) => KoanEnv.Gate.Allows(Magic(consent));
+
+    /// <summary>
+    /// The environment half of a refusal, for adapters composing a message that also names the table. Kept
+    /// identical across adapters so operators recognize it wherever they meet it.
+    /// </summary>
+    public const string Refusal =
+        "Automatic DDL is not allowed in Production. Provision the schema out of band, set AllowProductionDdl "
+        + "on the source, or set Koan:AllowMagicInProduction=true to accept automatic DDL framework-wide.";
+}

--- a/src/Koan.Data.Relational/Orchestration/RelationalSchemaOrchestrator.cs
+++ b/src/Koan.Data.Relational/Orchestration/RelationalSchemaOrchestrator.cs
@@ -278,16 +278,15 @@ internal sealed class RelationalSchemaOrchestrator :
             ? "StorageLifecycle=External forbids shape mutation."
             : policy.Ddl != RelationalDdlPolicy.AutoCreate
                 ? $"DDL is disabled by policy '{policy.Ddl}'."
-                : "DDL is not allowed in production.";
+                : RelationalDdlGate.Refusal;
         throw new InvalidOperationException(
-            $"Relational schema creation was rejected for {features.ProviderName}/{schema}/{table}. {reason} " +
-            "Set the selected provider's DdlPolicy to AutoCreate and explicitly allow production DDL only when intended.");
+            $"Relational schema creation was rejected for {features.ProviderName}/{schema}/{table}. {reason}");
     }
 
     private static bool IsDdlAllowed(RelationalSchemaPolicy policy) =>
         policy.StorageLifecycle == Koan.Data.Abstractions.Sources.StorageLifecycle.Managed &&
         policy.Ddl == RelationalDdlPolicy.AutoCreate &&
-        (!Koan.Core.KoanEnv.IsProduction || policy.AllowProductionDdl);
+        RelationalDdlGate.Allowed(policy.AllowProductionDdl);
 
     private static bool DefinitionEquals(RelationalColumnDefinition expected, RelationalColumnDefinition actual) =>
         expected.ClrType == actual.ClrType &&

--- a/src/Koan.Identity/Initialization/SecIdentityModule.cs
+++ b/src/Koan.Identity/Initialization/SecIdentityModule.cs
@@ -75,10 +75,10 @@ public sealed class SecIdentityModule : KoanModule
         var options = services.GetService<IOptions<IdentityOptions>>()?.Value ?? new IdentityOptions();
         var logger = services.GetService<ILoggerFactory>()?.CreateLogger("Koan.Identity");
 
-        var posture = IdentityPostureResolver.Resolve(env.IsDevelopment(), options.Posture);
+        var posture = IdentityPostureResolver.Resolve(KoanEnv.Gate.DevelopmentOnly(env), options.Posture);
 
         // Fail-closed (mirrors Trust/Tenancy): Open auto-seeds dev users and is legal only in Development.
-        if (posture == IdentityPosture.Open && !env.IsDevelopment())
+        if (posture == IdentityPosture.Open && !KoanEnv.Gate.DevelopmentOnly(env))
             throw new InvalidOperationException(
                 "SEC-0007 fail-closed: Identity posture 'Open' (which auto-seeds dev users) is only valid in " +
                 $"Development; environment '{env.EnvironmentName}' must resolve 'Closed'. Remove the " +
@@ -86,7 +86,7 @@ public sealed class SecIdentityModule : KoanModule
 
         logger?.LogInformation("Koan.Identity posture resolved: {Posture}.", posture);
 
-        if (ShouldSeedDevUsers(env.IsDevelopment(), posture, options.SeedDevUsers))
+        if (ShouldSeedDevUsers(KoanEnv.Gate.DevelopmentOnly(env), posture, options.SeedDevUsers))
         {
             var reconciler = services.GetService<IIdentityReconciler>() ?? new IdentityReconciler();
             var devUser = (options.DevUser ?? Environment.UserName).Trim();
@@ -125,8 +125,8 @@ public sealed class SecIdentityModule : KoanModule
         var auditSnapshotMode = cfg.GetValue<Audit.IdentityAuditSnapshotMode?>(
             $"{IdentityOptions.SectionPath}:{nameof(IdentityOptions.AuditSnapshotMode)}")
             ?? Audit.IdentityAuditSnapshotMode.PrivacySafe;
-        var posture = IdentityPostureResolver.Resolve(env.IsDevelopment(), configured);
-        var source = configured is null ? (env.IsDevelopment() ? "dev-open" : "closed") : "override";
+        var posture = IdentityPostureResolver.Resolve(KoanEnv.Gate.DevelopmentOnly(env), configured);
+        var source = configured is null ? (KoanEnv.Gate.DevelopmentOnly(env) ? "dev-open" : "closed") : "override";
         module.SetSetting("Identity", b => b.Value(
             $"posture={posture} ({source}); audit={auditSnapshotMode}; erasure=preview+owner-receipt; " +
             "durable person + IUserStore/IExternalIdentityStore reconciliation; no per-MAU axis (SEC-0007 D2)"));

--- a/src/Koan.Mcp.Explorer/Hosting/McpExplorerEndpointContributor.cs
+++ b/src/Koan.Mcp.Explorer/Hosting/McpExplorerEndpointContributor.cs
@@ -1,3 +1,4 @@
+using Koan.Core;
 using System;
 using System.Linq;
 using System.Text.Json;
@@ -67,7 +68,7 @@ internal sealed class McpExplorerEndpointContributor : IKoanEndpointContributor
     {
         var env = context.RequestServices.GetRequiredService<IHostEnvironment>();
         var options = context.RequestServices.GetRequiredService<IOptionsMonitor<McpExplorerOptions>>().CurrentValue;
-        if (!AccessMapGate.Allowed(env.IsDevelopment(), context.User, options))
+        if (!AccessMapGate.Allowed(KoanEnv.Gate.DevelopmentOnly(env), context.User, options))
         {
             context.Response.StatusCode = StatusCodes.Status404NotFound;
             return;

--- a/src/Koan.Mcp.Explorer/Initialization/McpExplorerModule.cs
+++ b/src/Koan.Mcp.Explorer/Initialization/McpExplorerModule.cs
@@ -29,7 +29,7 @@ public sealed class McpExplorerModule : KoanModule
         ArgumentNullException.ThrowIfNull(module);
 
         var configured = configuration.GetValue<bool?>("Koan:Mcp:Explorer:Enabled");
-        var enabled = configured ?? (!environment.IsProduction() && !KoanEnv.InContainer);
+        var enabled = configured ?? !KoanEnv.Gate.LooksDeployed(environment);
         if (!enabled)
         {
             module.Describe(Version, "mcp.explorer: inactive");
@@ -40,7 +40,7 @@ public sealed class McpExplorerModule : KoanModule
         route = string.IsNullOrWhiteSpace(route) ? "/mcp" : route.TrimEnd('/');
         var role = configuration["Koan:Mcp:Explorer:AdminRole"];
         var scope = configuration["Koan:Mcp:Explorer:AdminScope"];
-        var accessMap = environment.IsDevelopment()
+        var accessMap = KoanEnv.Gate.DevelopmentOnly(environment)
             ? "development"
             : !string.IsNullOrWhiteSpace(role) || !string.IsNullOrWhiteSpace(scope)
                 ? "admin-gated"

--- a/src/Koan.Mcp.Explorer/McpExplorerOptions.cs
+++ b/src/Koan.Mcp.Explorer/McpExplorerOptions.cs
@@ -15,7 +15,7 @@ public sealed class McpExplorerOptions
     /// </summary>
     public bool Enabled
     {
-        get => _enabled ?? !(KoanEnv.IsProduction || KoanEnv.InContainer);
+        get => _enabled ?? !KoanEnv.Gate.LooksDeployed();
         set => _enabled = value;
     }
 

--- a/src/Koan.Mcp/Hosting/HttpSseTransport.cs
+++ b/src/Koan.Mcp/Hosting/HttpSseTransport.cs
@@ -59,7 +59,7 @@ public sealed class HttpSseTransport
             return;
         }
 
-        if (!options.RequireAuthentication && (KoanEnv.IsProduction || KoanEnv.InContainer))
+        if (!options.RequireAuthentication && KoanEnv.Gate.LooksDeployed())
         {
             _logger.LogWarning(
                 "SECURITY WARNING: legacy MCP HTTP+SSE transport running without authentication in {Environment}.",

--- a/src/Koan.Mcp/Hosting/StreamableHttpTransport.cs
+++ b/src/Koan.Mcp/Hosting/StreamableHttpTransport.cs
@@ -339,7 +339,7 @@ public sealed class StreamableHttpTransport
             return false;
         }
 
-        if (!options.RequireAuthentication && (KoanEnv.IsProduction || KoanEnv.InContainer))
+        if (!options.RequireAuthentication && KoanEnv.Gate.LooksDeployed())
         {
             _logger.LogWarning(
                 "SECURITY WARNING: MCP Streamable HTTP transport running without authentication in {Environment}.",

--- a/src/Koan.Mcp/Options/McpServerOptions.cs
+++ b/src/Koan.Mcp/Options/McpServerOptions.cs
@@ -54,7 +54,7 @@ public sealed class McpServerOptions
     /// </summary>
     public bool RequireAuthentication
     {
-        get => _requireAuthentication ?? (KoanEnv.IsProduction || KoanEnv.InContainer);
+        get => _requireAuthentication ?? KoanEnv.Gate.LooksDeployed();
         set => _requireAuthentication = value;
     }
 

--- a/src/Koan.Media.Web/Routing/MediaSourceDiscovery.cs
+++ b/src/Koan.Media.Web/Routing/MediaSourceDiscovery.cs
@@ -9,6 +9,8 @@ namespace Koan.Media.Web.Routing;
 /// <summary>Compiles the default media source choice from the application's concrete media Entities.</summary>
 internal static class MediaSourceDiscovery
 {
+    /// <param name="CandidateCount">How many concrete media Entities the application declares.</param>
+    /// <param name="Summary">One line for startup reporting, naming the choice or why there was none.</param>
     /// <param name="SourceRegistered">
     /// False when the application declares no media Entity at all. Media Web then composes inertly:
     /// referencing a projection is the intent to expose media once there is some, not an assertion that

--- a/src/Koan.Tenancy.Web/Initialization/KoanTenancyWebModule.cs
+++ b/src/Koan.Tenancy.Web/Initialization/KoanTenancyWebModule.cs
@@ -73,7 +73,7 @@ public sealed class KoanTenancyWebModule : KoanModule
         // naive env check — otherwise a dev host with Posture=Closed would announce "just-works" while the gate 403s.
         var postureOverride = Enum.TryParse<TenancyPosture>(cfg[$"{TenancyOptions.SectionPath}:Posture"], ignoreCase: true, out var p)
             ? (TenancyPosture?)p : null;
-        var posture = TenancyPostureResolver.Resolve(env.IsDevelopment(), postureOverride) == TenancyPosture.Open
+        var posture = TenancyPostureResolver.Resolve(KoanEnv.Gate.DevelopmentOnly(env), postureOverride) == TenancyPosture.Open
             ? "Open (dev — just-works)"
             : "Closed (requires grant, fail-closed)";
         var operators = cfg.GetSection($"{section}:Grant:Operators").GetChildren().Count();

--- a/src/Koan.Tenancy/Initialization/TenancyModule.cs
+++ b/src/Koan.Tenancy/Initialization/TenancyModule.cs
@@ -55,7 +55,7 @@ public sealed class TenancyModule : KoanModule, IContributeTo<SegmentationContri
         var runtime = services.GetRequiredService<TenancyRuntime>();
         var logger = services.GetService<ILoggerFactory>()?.CreateLogger("Koan.Tenancy");
 
-        if (runtime.Posture == TenancyPosture.Open && !env.IsDevelopment())
+        if (runtime.Posture == TenancyPosture.Open && !KoanEnv.Gate.DevelopmentOnly(env))
             throw new InvalidOperationException(
                 "Tenancy posture resolved to Open outside Development. Remove the " +
                 $"{TenancyOptions.SectionPath}:Posture=Open override or run the host in Development.");
@@ -77,9 +77,9 @@ public sealed class TenancyModule : KoanModule, IContributeTo<SegmentationContri
         var overrideRaw = cfg[$"{TenancyOptions.SectionPath}:Posture"];
         TenancyPosture? overridePosture =
             Enum.TryParse<TenancyPosture>(overrideRaw, ignoreCase: true, out var parsed) ? parsed : null;
-        var posture = TenancyPostureResolver.Resolve(env.IsDevelopment(), overridePosture);
+        var posture = TenancyPostureResolver.Resolve(KoanEnv.Gate.DevelopmentOnly(env), overridePosture);
 
-        var source = overridePosture is null ? (env.IsDevelopment() ? "dev-open" : "closed") : "override";
+        var source = overridePosture is null ? (KoanEnv.Gate.DevelopmentOnly(env) ? "dev-open" : "closed") : "override";
         module.SetSetting("Tenancy", b => b.Value(
             $"posture={posture} ({source}); segmentation=tenant/hard; realization=pillar-owned"));
     }

--- a/src/Koan.Tenancy/TenancyPosture.cs
+++ b/src/Koan.Tenancy/TenancyPosture.cs
@@ -4,8 +4,8 @@ namespace Koan.Tenancy;
 /// The tenancy posture (ARCH-0099 §1) — derived once at boot from the in-core <see cref="Koan.Core.KoanEnv"/>
 /// snapshot, never a cross-environment flag. <see cref="Open"/> in Development (the developer lands in a working
 /// control plane; a tenant-scoped op with no tenant in scope is warned, not blocked); <see cref="Closed"/>
-/// otherwise (Production, Staging, unset, or ambiguous — the ASP.NET <c>IsDevelopment()</c> rule resolves the
-/// ambiguous case to closed), where the same op fails closed.
+/// otherwise (Production, Staging, unset, or ambiguous — <see cref="Koan.Core.KoanEnv.Gate.DevelopmentOnly"/>
+/// resolves the ambiguous case to closed), where the same op fails closed.
 ///
 /// <para>This replaces the retired <c>TenancyMode.Off</c> default: referencing <c>Koan.Tenancy</c> activates
 /// tenancy (Reference = Intent), and the posture — not a flag — decides how strict it is. <see cref="Closed"/>

--- a/src/Koan.Tenancy/TenancyRuntime.cs
+++ b/src/Koan.Tenancy/TenancyRuntime.cs
@@ -1,3 +1,4 @@
+using Koan.Core;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
@@ -5,8 +6,9 @@ namespace Koan.Tenancy;
 
 /// <summary>
 /// The resolved tenancy runtime (ARCH-0099 §1) — computes the <see cref="TenancyPosture"/> once, per host, from
-/// the <b>per-host</b> <see cref="IHostEnvironment"/> (the same ASP.NET <c>IsDevelopment()</c> rule the in-core
-/// <c>KoanEnv</c> snapshot is itself computed from) plus any explicit <see cref="TenancyOptions.Posture"/>
+/// the <b>per-host</b> <see cref="IHostEnvironment"/> (through <see cref="Koan.Core.KoanEnv.Gate.DevelopmentOnly"/>,
+/// so an open posture obeys the same rule as every other development-only surface) plus any explicit
+/// <see cref="TenancyOptions.Posture"/>
 /// override, and holds it so the hot-path gate reads a field, not a derivation.
 ///
 /// <para>It is deliberately <b>per-host</b>, not the process-global <c>KoanEnv</c> snapshot: <c>KoanEnv</c> latches
@@ -23,6 +25,6 @@ public sealed class TenancyRuntime
     public TenancyRuntime(IOptions<TenancyOptions> options, IHostEnvironment environment)
     {
         var o = options?.Value ?? new TenancyOptions();
-        Posture = TenancyPostureResolver.Resolve(environment?.IsDevelopment() ?? false, o.Posture);
+        Posture = TenancyPostureResolver.Resolve(KoanEnv.Gate.DevelopmentOnly(environment), o.Posture);
     }
 }

--- a/src/Koan.Web.Admin/Controllers/KoanAdminStatusController.cs
+++ b/src/Koan.Web.Admin/Controllers/KoanAdminStatusController.cs
@@ -58,7 +58,7 @@ public sealed class KoanAdminStatusController(
         return Ok(BuildHealth());
     }
 
-    private bool IsActive() => environment.IsDevelopment() && options.Value.Enabled;
+    private bool IsActive() => KoanEnv.Gate.DevelopmentOnly(environment) && options.Value.Enabled;
 
     private KoanAdminHealthDocument BuildHealth()
     {

--- a/src/Koan.Web.Admin/Controllers/KoanAdminUiController.cs
+++ b/src/Koan.Web.Admin/Controllers/KoanAdminUiController.cs
@@ -1,3 +1,4 @@
+using Koan.Core;
 using Koan.Web.Admin.Infrastructure;
 using Koan.Web.Admin.Options;
 using Microsoft.AspNetCore.Mvc;
@@ -33,7 +34,7 @@ public sealed class KoanAdminUiController(
     public IActionResult Assets(string? asset)
         => IsActive() ? Serve(asset) : NotFound();
 
-    private bool IsActive() => environment.IsDevelopment() && options.Value.Enabled;
+    private bool IsActive() => KoanEnv.Gate.DevelopmentOnly(environment) && options.Value.Enabled;
 
     private IActionResult Serve(string? asset)
     {

--- a/src/Koan.Web.Admin/Infrastructure/KoanAdminAuthorizationFilter.cs
+++ b/src/Koan.Web.Admin/Infrastructure/KoanAdminAuthorizationFilter.cs
@@ -1,3 +1,4 @@
+using Koan.Core;
 using Koan.Web.Admin.Options;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -15,7 +16,7 @@ internal sealed class KoanAdminAuthorizationFilter(
     public async Task OnAuthorizationAsync(AuthorizationFilterContext context)
     {
         var snapshot = options.Value;
-        if (!environment.IsDevelopment() || !snapshot.Enabled)
+        if (!KoanEnv.Gate.DevelopmentOnly(environment) || !snapshot.Enabled)
         {
             context.Result = new NotFoundResult();
             return;

--- a/src/Koan.Web.Admin/Infrastructure/KoanAdminDevelopmentPolicySetup.cs
+++ b/src/Koan.Web.Admin/Infrastructure/KoanAdminDevelopmentPolicySetup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using Koan.Core;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Koan.Web.Admin.Options;
@@ -10,7 +11,7 @@ internal sealed class KoanAdminDevelopmentPolicySetup(IHostEnvironment environme
 {
     public void Configure(AuthorizationOptions authorization)
     {
-        if (!environment.IsDevelopment())
+        if (!KoanEnv.Gate.DevelopmentOnly(environment))
         {
             return;
         }

--- a/src/Koan.Web.Admin/Initialization/AdminModule.cs
+++ b/src/Koan.Web.Admin/Initialization/AdminModule.cs
@@ -53,7 +53,7 @@ public sealed class AdminModule : KoanModule
             defaults.Authorization.AutoCreateDevelopmentPolicy);
 
         var routes = KoanAdminPathUtility.BuildMap(prefix.Value);
-        var active = env.IsDevelopment() && enabled.Value;
+        var active = KoanEnv.Gate.DevelopmentOnly(env) && enabled.Value;
 
         module.AddSetting(AdminProvenanceItems.Enabled, FromConfigurationValue(enabled), active,
             sourceKey: enabled.ResolvedKey, usedDefault: enabled.UsedDefault);
@@ -64,7 +64,7 @@ public sealed class AdminModule : KoanModule
         module.AddSetting(AdminProvenanceItems.AuthorizationAutoCreatePolicy, FromConfigurationValue(autoPolicy), autoPolicy.Value,
             sourceKey: autoPolicy.ResolvedKey, usedDefault: autoPolicy.UsedDefault);
 
-        if (!env.IsDevelopment())
+        if (!KoanEnv.Gate.DevelopmentOnly(env))
         {
             module.AddNote("Koan Web Admin is Development-only; routes remain inactive in this environment.");
             return;

--- a/src/Koan.Web.Auth.Server/AuthServerModule.cs
+++ b/src/Koan.Web.Auth.Server/AuthServerModule.cs
@@ -49,7 +49,7 @@ public sealed class AuthServerModule : KoanModule
         services.AddDataProtection();
         services.AddSingleton<PersistedIssuerKeyStore>();
         services.Replace(ServiceDescriptor.Singleton<IIssuerKeyStore>(sp =>
-            sp.GetRequiredService<IHostEnvironment>().IsDevelopment()
+            KoanEnv.Gate.DevelopmentOnly(sp.GetRequiredService<IHostEnvironment>())
                 ? new EphemeralIssuerKeyStore()
                 : sp.GetRequiredService<PersistedIssuerKeyStore>()));
         services.AddHostedService<IssuerKeyRotationService>();
@@ -81,7 +81,7 @@ public sealed class AuthServerModule : KoanModule
     /// <summary>
     /// SEC-0006 addendum (WEB-0072 P3) — seed the well-known public dev client (<see cref="DevExplorerClientId"/>)
     /// the MCP Explorer's device-flow exerciser posts against. Two-gate fail-closed, mirroring the dev-token
-    /// endpoint: the <c>IHostEnvironment.IsDevelopment()</c> gate is the real safety (a guessable
+    /// endpoint: the <see cref="KoanEnv.Gate.DevelopmentOnly"/> gate is the real safety (a guessable
     /// pre-registered client must never exist in production), with <see cref="AuthServerOptions.SeedDevClient"/> as
     /// the operator opt-out. Idempotent (seed-once). The client is <b>public</b> — its security rests on PKCE + the
     /// device-consent ceremony, not a secret — and carries no redirect URIs (the device grant never redirects).
@@ -97,7 +97,7 @@ public sealed class AuthServerModule : KoanModule
     private static async Task SeedDevExplorerClientAsync(
         IHostEnvironment env, AuthServerOptions options, IServiceProvider services, CancellationToken ct)
     {
-        if (!env.IsDevelopment() || !options.SeedDevClient) return;
+        if (!KoanEnv.Gate.DevelopmentOnly(env) || !options.SeedDevClient) return;
 
         using var scope = AppHost.PushScope(services);
 
@@ -117,7 +117,7 @@ public sealed class AuthServerModule : KoanModule
     public override void Report(ProvenanceModuleWriter module, IConfiguration cfg, IHostEnvironment env)
     {
         module.Describe(Version);
-        module.AddNote(env.IsDevelopment()
+        module.AddNote(KoanEnv.Gate.DevelopmentOnly(env)
             ? $"Embedded OAuth 2.1 AS — ephemeral ES256 key; dev-token endpoint (GET {AuthServerRoutes.DevToken}) ENABLED."
             : "Embedded OAuth 2.1 AS — persisted + rotating ES256 key (encrypted-at-rest); dev-token endpoint is dev-only (404 here).");
     }

--- a/src/Koan.Web.Auth.Server/Hosting/DevTokenEndpoint.cs
+++ b/src/Koan.Web.Auth.Server/Hosting/DevTokenEndpoint.cs
@@ -1,3 +1,4 @@
+using Koan.Core;
 using Koan.Web.Auth.Server.Options;
 using Koan.Security.Trust.Issuer;
 using Microsoft.AspNetCore.Http;
@@ -26,7 +27,7 @@ internal static class DevTokenEndpoint
         var options = ctx.RequestServices.GetRequiredService<IOptions<AuthServerOptions>>().Value;
 
         // HARD dev-gate, fail-closed: 404 (don't even acknowledge the endpoint) outside Development or when disabled.
-        if (!env.IsDevelopment() || !options.DevTokenEnabled)
+        if (!KoanEnv.Gate.DevelopmentOnly(env) || !options.DevTokenEnabled)
         {
             ctx.Response.StatusCode = StatusCodes.Status404NotFound;
             return;

--- a/src/Koan.Web.Auth.Server/Keys/IssuerKeyGuard.cs
+++ b/src/Koan.Web.Auth.Server/Keys/IssuerKeyGuard.cs
@@ -12,6 +12,9 @@ internal static class IssuerKeyGuard
     public static void EnsurePersistedOutsideDevelopment(bool isEphemeral, IHostEnvironment env, bool acknowledged)
     {
         if (!isEphemeral) return;
+        // Production AND Staging, which is neither KoanEnv.Gate predicate: this guard protects token continuity,
+        // and Staging issues tokens real clients hold. Its acknowledgement is a dedicated option, deliberately not
+        // Koan:AllowMagicInProduction — a convenience flag must not be able to destabilize a published JWKS.
         if (!(env.IsProduction() || env.IsStaging())) return;
         if (acknowledged) return;
 

--- a/src/Koan.Web.Auth.Server/Keys/IssuerKeyRotationService.cs
+++ b/src/Koan.Web.Auth.Server/Keys/IssuerKeyRotationService.cs
@@ -34,7 +34,9 @@ internal sealed class IssuerKeyRotationService : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        // Development uses an ephemeral key — nothing to rotate or persist.
+        // Development uses an ephemeral key — nothing to rotate or persist. This reads the environment directly
+        // rather than KoanEnv.Gate.DevelopmentOnly: the gate answers "may this surface exist", and no surface is
+        // being gated here — a background schedule simply has no work to do.
         if (_env.IsDevelopment()) return;
 
         var checkEvery = _options.KeyRotationInterval < TimeSpan.FromHours(4)

--- a/src/Koan.Web.Auth/Hosting/DevIdentityContributor.cs
+++ b/src/Koan.Web.Auth/Hosting/DevIdentityContributor.cs
@@ -1,3 +1,4 @@
+using Koan.Core;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using Koan.Security.Trust.Dev;
@@ -17,7 +18,7 @@ internal sealed class DevIdentityContributor(
 
     public ValueTask ContributeAsync(WebContext context)
     {
-        if (environment.IsDevelopment()
+        if (KoanEnv.Gate.DevelopmentOnly(environment)
             && DevIdentity.Resolve(context.HttpContext, options.Value) is { } principal)
             context.UsePrincipal(principal);
         return ValueTask.CompletedTask;

--- a/src/Koan.Web.Extensions/Authorization/KoanAuthorizationServiceCollectionExtensions.cs
+++ b/src/Koan.Web.Extensions/Authorization/KoanAuthorizationServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Koan.Core;
+using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Koan.Web.Extensions.Authorization.Internal;
@@ -40,7 +41,7 @@ public static class KoanAuthorizationServiceCollectionExtensions
                 new DelegateClaimsTransformation(principal =>
                 {
                     var env = sp.GetRequiredService<IHostEnvironment>();
-                    if (!env.IsDevelopment())
+                    if (!KoanEnv.Gate.DevelopmentOnly(env))
                     {
                         return Task.FromResult(principal);
                     }

--- a/src/Koan.Web.OpenApi/Hosting/KoanOpenApiStartupFilter.cs
+++ b/src/Koan.Web.OpenApi/Hosting/KoanOpenApiStartupFilter.cs
@@ -1,3 +1,4 @@
+using Koan.Core;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
@@ -121,7 +122,7 @@ internal sealed class KoanOpenApiStartupFilter(
     private static ResolvedOpenApiOptions Resolve(KoanOpenApiOptions options, IHostEnvironment environment)
     {
         var documentEnabled = options.Enabled ?? true;
-        var uiEnabled = documentEnabled && (options.EnableUi ?? environment.IsDevelopment());
+        var uiEnabled = documentEnabled && (options.EnableUi ?? KoanEnv.Gate.DevelopmentOnly(environment));
 
         if (documentEnabled && string.IsNullOrWhiteSpace(options.RoutePattern))
         {
@@ -145,7 +146,7 @@ internal sealed class KoanOpenApiStartupFilter(
         return new ResolvedOpenApiOptions(
             documentEnabled,
             uiEnabled,
-            uiEnabled && !environment.IsDevelopment() && options.RequireAuthenticationOutsideDevelopment,
+            uiEnabled && !KoanEnv.Gate.DevelopmentOnly(environment) && options.RequireAuthenticationOutsideDevelopment,
             routePattern,
             documentPath,
             uiRoutePrefix,

--- a/src/Koan.Web.OpenApi/Initialization/OpenApiModule.cs
+++ b/src/Koan.Web.OpenApi/Initialization/OpenApiModule.cs
@@ -131,11 +131,11 @@ public sealed class OpenApiModule : KoanModule
         string RoutePattern,
         string UiRoutePrefix,
         bool RequireAuthenticationOutsideDevelopment,
-        bool IsDevelopment)
+        bool AllowsDevelopmentSurfaces)
     {
         public bool DocumentEnabled => Enabled ?? true;
-        public bool UiEnabled => DocumentEnabled && (EnableUi ?? IsDevelopment);
-        public bool RequiresAuthentication => UiEnabled && !IsDevelopment && RequireAuthenticationOutsideDevelopment;
+        public bool UiEnabled => DocumentEnabled && (EnableUi ?? AllowsDevelopmentSurfaces);
+        public bool RequiresAuthentication => UiEnabled && !AllowsDevelopmentSurfaces && RequireAuthenticationOutsideDevelopment;
         public string DocumentRoute => RoutePattern.Replace("{documentName}", KoanOpenApiOptions.DefaultDocumentName, StringComparison.OrdinalIgnoreCase);
         public string UiRoute => "/" + UiRoutePrefix.Trim('/');
     }

--- a/src/Koan.Web.OpenApi/Initialization/OpenApiModule.cs
+++ b/src/Koan.Web.OpenApi/Initialization/OpenApiModule.cs
@@ -122,7 +122,7 @@ public sealed class OpenApiModule : KoanModule
             routePattern,
             uiRoute,
             requireAuthentication,
-            env.IsDevelopment());
+            KoanEnv.Gate.DevelopmentOnly(env));
     }
 
     private sealed record OpenApiOptionSnapshot(

--- a/src/Koan.Web/Controllers/WellKnownController.cs
+++ b/src/Koan.Web/Controllers/WellKnownController.cs
@@ -31,7 +31,7 @@ public sealed class WellKnownController(
     IKoanRuntimeFacts runtimeFacts
 ) : ControllerBase
 {
-    private bool CanExposeObservability() => env.IsDevelopment() || (webOptions?.Value?.ExposeObservabilitySnapshot == true);
+    private bool CanExposeObservability() => KoanEnv.Gate.DevelopmentOnly(env) || (webOptions?.Value?.ExposeObservabilitySnapshot == true);
 
     [HttpGet("observability")]
     public IActionResult Observability()
@@ -50,7 +50,7 @@ public sealed class WellKnownController(
 
         var payload = new
         {
-            enabled = opts.Enabled && (!string.IsNullOrWhiteSpace(otlpEndpoint) || env.IsDevelopment()),
+            enabled = opts.Enabled && (!string.IsNullOrWhiteSpace(otlpEndpoint) || KoanEnv.Gate.DevelopmentOnly(env)),
             resource = new { serviceName, serviceVersion, serviceInstanceId },
             traces = new
             {

--- a/tests/Suites/Core/Koan.Core.Tests/Hosting/EnvironmentGateConformanceSpec.cs
+++ b/tests/Suites/Core/Koan.Core.Tests/Hosting/EnvironmentGateConformanceSpec.cs
@@ -1,0 +1,180 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.RegularExpressions;
+using AwesomeAssertions;
+using Xunit;
+
+namespace Koan.Core.Tests.Hosting;
+
+/// <summary>
+/// The structural half of ARCH-0128. <see cref="EnvironmentGateSpec"/> pins what the gate does; this spec
+/// pins that capabilities actually use it.
+///
+/// <para>A written law nobody reads is a law nobody follows. The drift ARCH-0128 fixed happened while the
+/// rule was already documented, because a direct <c>IsDevelopment()</c> read compiles, passes review, and
+/// looks exactly like the correct code. So the check is structural: every direct read of the environment in
+/// <c>src/</c> is enumerated below with the reason it is allowed, and a new one fails the build with an
+/// explanation of which gate to use instead.</para>
+///
+/// <para>This is a ratchet in both directions. Adding a read fails; removing one from an allowed file also
+/// fails, so the list cannot quietly accumulate entries that stopped being true.</para>
+/// </summary>
+public sealed class EnvironmentGateConformanceSpec
+{
+    /// <summary>
+    /// Every file in <c>src/</c> permitted to read the environment directly, with its per-file count and the
+    /// reason it does not go through <see cref="KoanEnv.Gate"/>.
+    ///
+    /// <para><b>Adding an entry here is a design decision, not a formality.</b> The question to answer first
+    /// is which named decision you are making — see the failure message below. Diagnostics (log level,
+    /// banner, health detail) legitimately read the environment; capability gating does not.</para>
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, (int Count, string Why)> Allowed =
+        new Dictionary<string, (int, string)>(StringComparer.Ordinal)
+        {
+            ["src/Koan.Core/Hosting/Runtime/AppRuntime.cs"] =
+                (2, "Diagnostics: how much of the startup banner to print."),
+            ["src/Koan.Core/ServiceCollectionExtensions.cs"] =
+                (2, "Diagnostics: default log level and the Koan log filter."),
+            ["src/Koan.Observability/Infrastructure/ObservabilityPlan.cs"] =
+                (2, "Diagnostics: sampling and exporter defaults."),
+            ["src/Koan.Web/Controllers/HealthController.cs"] =
+                (1, "Diagnostics: how much detail the health payload carries."),
+            ["src/Koan.Mcp/Hosting/HttpSseTransport.cs"] =
+                (1, "Transport-local heuristic: warns on plaintext in Production with no TLS-terminating "
+                  + "proxy in front (IsProduction && !InContainer). One concept in one pillar."),
+            ["src/Koan.Mcp/Hosting/StreamableHttpTransport.cs"] =
+                (2, "Transport-local heuristic: the same plaintext warning, on two request paths."),
+            ["src/Koan.Data.Core/Axes/DataAxisPreflight.cs"] =
+                (1, "ARCH-0128 exception: a confirmed cross-tenant read is not a convenience, so nothing may "
+                  + "unlock it. A KoanMagic gate would let Koan:AllowMagicInProduction unlock a data leak."),
+            ["src/Koan.Web.Auth.Server/Keys/IssuerKeyGuard.cs"] =
+                (2, "ARCH-0128 exception: guards Production AND Staging (both issue tokens real clients "
+                  + "hold), with its own acknowledgement rather than the shared flag."),
+            ["src/Koan.Web.Auth.Server/Keys/IssuerKeyRotationService.cs"] =
+                (1, "ARCH-0128 exception: a background schedule with no work to do in Development. No "
+                  + "surface is gated, so no gate applies."),
+        };
+
+    /// <summary>
+    /// <c>KoanEnv</c> and its gate are the mechanism, not consumers of it. Counting their own declarations
+    /// would make every snapshot edit a failure here, which teaches nothing.
+    /// </summary>
+    private static readonly HashSet<string> Mechanism =
+        new(StringComparer.Ordinal) { "KoanEnv.cs", "KoanEnvGate.cs" };
+
+    private static readonly Regex EnvironmentRead =
+        new(@"\b(IsDevelopment|IsProduction|IsStaging)\b", RegexOptions.Compiled);
+
+    // Trailing comments are not code. The negative lookbehind keeps "http://" in a string from truncating
+    // the line before the part that matters.
+    private static readonly Regex TrailingComment =
+        new(@"(?<!:)//.*$", RegexOptions.Compiled);
+
+    [Fact(DisplayName = "no capability reads the environment directly outside the enumerated exceptions")]
+    public void Every_direct_environment_read_is_accounted_for()
+    {
+        var actual = ScanSource();
+
+        var added = actual.Keys.Where(file => !Allowed.ContainsKey(file)).OrderBy(f => f, StringComparer.Ordinal).ToList();
+        var removed = Allowed.Keys.Where(file => !actual.ContainsKey(file)).OrderBy(f => f, StringComparer.Ordinal).ToList();
+        var changed = actual.Keys.Where(file => Allowed.TryGetValue(file, out var e) && e.Count != actual[file])
+            .OrderBy(f => f, StringComparer.Ordinal).ToList();
+
+        if (added.Count == 0 && removed.Count == 0 && changed.Count == 0) return;
+
+        var report = new StringBuilder();
+        report.AppendLine("Direct environment reads in src/ no longer match ARCH-0128's enumerated set.");
+        report.AppendLine();
+
+        if (added.Count > 0)
+        {
+            report.AppendLine("NEW direct read(s) — pick the named decision you are actually making:");
+            report.AppendLine();
+            report.AppendLine("  A convenience that is safe everywhere but risky in Production (auto-DDL,");
+            report.AppendLine("  auto-discovery, a local key file):");
+            report.AppendLine("      KoanEnv.Gate.Enforce(new KoanMagic(");
+            report.AppendLine("          Capability: \"...\", Risk: \"...\", Remedy: \"...\",");
+            report.AppendLine("          Consent: options.YourOptIn), environment, logger);");
+            report.AppendLine("      Production is the gate, not Development — it runs in Staging, Test and CI.");
+            report.AppendLine("      Use Gate.Announce instead when skipping is a coherent outcome.");
+            report.AppendLine();
+            report.AppendLine("  A surface that must NOT exist outside Development (admin UI, dev tokens,");
+            report.AppendLine("  seeded credentials). No flag unlocks it, deliberately:");
+            report.AppendLine("      if (!KoanEnv.Gate.DevelopmentOnly(environment)) return;");
+            report.AppendLine();
+            report.AppendLine("  An unconfigured default, never an authorization:");
+            report.AppendLine("      options.Something ?? KoanEnv.Gate.LooksDeployed(environment)");
+            report.AppendLine();
+            report.AppendLine("  Diagnostics only (log level, banner, health detail) may read the environment");
+            report.AppendLine("  directly — add the file to Allowed in this spec, with the reason.");
+            report.AppendLine();
+            foreach (var file in added) report.AppendLine($"    + {file} ({actual[file]} read(s))");
+            report.AppendLine();
+        }
+
+        if (changed.Count > 0)
+        {
+            report.AppendLine("COUNT CHANGED in an allowed file — a new gate may have been added inside one:");
+            foreach (var file in changed)
+                report.AppendLine($"    ~ {file}: allowed {Allowed[file].Count}, found {actual[file]}  ({Allowed[file].Why})");
+            report.AppendLine();
+        }
+
+        if (removed.Count > 0)
+        {
+            report.AppendLine("NO LONGER PRESENT — good news; delete the entry so the list stays true:");
+            foreach (var file in removed) report.AppendLine($"    - {file}");
+            report.AppendLine();
+        }
+
+        report.Append("See docs/decisions/ARCH-0128-environment-posture-is-a-named-decision.md.");
+        Assert.Fail(report.ToString());
+    }
+
+    private static Dictionary<string, int> ScanSource()
+    {
+        var root = FindRepositoryRoot();
+        var source = Path.Combine(root, "src");
+        Directory.Exists(source).Should().BeTrue("the scan is meaningless without the source tree");
+
+        var found = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var path in Directory.EnumerateFiles(source, "*.cs", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(root, path).Replace('\\', '/');
+            if (relative.Contains("/obj/", StringComparison.Ordinal) ||
+                relative.Contains("/bin/", StringComparison.Ordinal)) continue;
+            if (Mechanism.Contains(Path.GetFileName(path))) continue;
+
+            var count = File.ReadLines(path).Sum(CountReads);
+            if (count > 0) found[relative] = count;
+        }
+
+        return found;
+    }
+
+    private static int CountReads(string line)
+    {
+        var trimmed = line.TrimStart();
+        if (trimmed.StartsWith("//", StringComparison.Ordinal) ||
+            trimmed.StartsWith("*", StringComparison.Ordinal) ||
+            trimmed.StartsWith("/*", StringComparison.Ordinal)) return 0;
+
+        return EnvironmentRead.Matches(TrailingComment.Replace(line, string.Empty)).Count;
+    }
+
+    // [CallerFilePath] is baked at compile time, which is the only reliable anchor: test output is
+    // redirected outside the repository, so walking up from the assembly location finds nothing.
+    private static string FindRepositoryRoot([CallerFilePath] string sourceFile = "")
+    {
+        foreach (var start in new[] { Path.GetDirectoryName(sourceFile)!, Environment.CurrentDirectory, AppContext.BaseDirectory })
+        {
+            for (var directory = new DirectoryInfo(start); directory is not null; directory = directory.Parent)
+            {
+                if (File.Exists(Path.Combine(directory.FullName, "Koan.sln"))) return directory.FullName;
+            }
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the Koan repository root.");
+    }
+}

--- a/tests/Suites/Core/Koan.Core.Tests/Hosting/EnvironmentGateSpec.cs
+++ b/tests/Suites/Core/Koan.Core.Tests/Hosting/EnvironmentGateSpec.cs
@@ -1,0 +1,96 @@
+using AwesomeAssertions;
+using Koan.Core;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Koan.Core.Tests.Hosting;
+
+/// <summary>
+/// The law every capability gate follows, pinned once here so no call site has to re-derive it: Production is
+/// the gate, not Development. Each of these cases corresponds to a real drift found in the tree — Staging
+/// blocked as if it were Production, and a documented escape hatch no call site consulted.
+/// </summary>
+public sealed class EnvironmentGateSpec
+{
+    private static readonly KoanMagic Sample = new(
+        Capability: "relational DDL",
+        Risk: "schema changes are applied directly to whatever database the connection string points at",
+        Remedy: "provision the schema out of band, or set AllowProductionDdl on the source");
+
+    [Theory(DisplayName = "every environment below Production runs the convenience")]
+    [InlineData("Development", MagicVerdict.Allowed)]
+    [InlineData("Staging", MagicVerdict.AllowedWithNotice)]
+    [InlineData("Test", MagicVerdict.AllowedWithNotice)]
+    [InlineData("", MagicVerdict.AllowedWithNotice)]
+    public void Below_production_the_convenience_runs(string environment, MagicVerdict expected)
+    {
+        // Gating on IsDevelopment() instead would refuse Test, Staging and CI, which is a functionality block
+        // wearing a safety rail's clothes.
+        KoanEnv.Gate.Evaluate(Sample, Env(environment)).Should().Be(expected);
+        KoanEnv.Gate.Allows(Sample, Env(environment)).Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Production refuses without consent")]
+    public void Production_refuses_without_consent()
+    {
+        KoanEnv.Gate.Evaluate(Sample, Env(Environments.Production)).Should().Be(MagicVerdict.Refused);
+        KoanEnv.Gate.Allows(Sample, Env(Environments.Production)).Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "the capability's own consent unlocks Production")]
+    public void Capability_consent_unlocks_production()
+    {
+        var consented = Sample with { Consent = true };
+
+        KoanEnv.Gate.Evaluate(consented, Env(Environments.Production))
+            .Should().Be(MagicVerdict.AllowedByConsent);
+    }
+
+    [Fact(DisplayName = "a refusal names the capability, the risk, the remedy, and the escape hatch")]
+    public void Refusal_explains_itself()
+    {
+        var refuse = () => KoanEnv.Gate.Enforce(Sample, Env(Environments.Production));
+
+        // A refusal an operator cannot act on is just an outage. Each clause earns its place.
+        refuse.Should().Throw<InvalidOperationException>()
+            .WithMessage("*refuses relational DDL in Production*")
+            .WithMessage("*connection string points at*")
+            .WithMessage("*AllowProductionDdl*")
+            .WithMessage("*Koan:AllowMagicInProduction=true*");
+    }
+
+    [Fact(DisplayName = "Enforce lets every non-Production environment through")]
+    public void Enforce_is_silent_below_production()
+    {
+        var run = () => KoanEnv.Gate.Enforce(Sample, Env(Environments.Staging));
+        run.Should().NotThrow();
+    }
+
+    [Fact(DisplayName = "Announce reports refusal instead of throwing")]
+    public void Announce_never_throws()
+    {
+        KoanEnv.Gate.Announce(Sample, logger: null, environment: Env(Environments.Production))
+            .Should().BeFalse("skipping is a coherent outcome for a discovery-shaped convenience");
+        KoanEnv.Gate.Announce(Sample, logger: null, environment: Env(Environments.Staging))
+            .Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "development-only surfaces exist only in Development")]
+    public void Development_only_is_exclusive_to_development()
+    {
+        KoanEnv.Gate.DevelopmentOnly(Env(Environments.Development)).Should().BeTrue();
+        KoanEnv.Gate.DevelopmentOnly(Env(Environments.Staging)).Should().BeFalse();
+        KoanEnv.Gate.DevelopmentOnly(Env(Environments.Production)).Should().BeFalse();
+    }
+
+    private static IHostEnvironment Env(string name) => new StubEnvironment(name);
+
+    private sealed class StubEnvironment(string name) : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = name;
+        public string ApplicationName { get; set; } = "Koan.Core.Tests";
+        public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}


### PR DESCRIPTION
Fast-forward release PR (`dev` → `main`). Landing is by `git merge --ff-only` per the
[release playbook](docs/engineering/nuget-publishing.md) — `main` requires linear history, so this PR
is the record rather than the merge mechanism.

## What changed

Capabilities gated on the environment by reading `IsDevelopment()` / `IsProduction()` directly,
re-deriving at each call site which fact answered "may this compose?". A survey found **43 decision
points across 33 files in four inconsistent spellings**, and three were live defects:

1. **Staging was Production, inconsistently.** Auto-DDL gated `!IsProduction` (ran in Staging); AI
   discovery gated `IsDevelopment` (did not). Nothing articulated why — two authors picked different booleans.
2. **A documented escape hatch no call site consulted.** DATA-0046 specifies `AllowMagicInProduction`
   as an unlock for auto-DDL. All three relational DDL gates checked only `AllowProductionDdl`. The flag
   was documented, configurable, reported at boot, and **inert**.
3. **A safety rail shipped as a functionality block** — an earlier Classification gate read
   `!IsDevelopment()`, breaking Test, Staging, and CI.

## The design

`KoanEnv.Gate` names **three** decisions rather than wrapping one boolean:

| Gate | Question | Unlockable in Production? |
|---|---|---|
| `Enforce`/`Allows`/`Announce` (a `KoanMagic`) | May this convenience run automatically? | Yes — own option, or `Koan:AllowMagicInProduction` |
| `DevelopmentOnly` | May this surface exist at all? | **No.** Nothing unlocks it |
| `LooksDeployed` | What should the unconfigured default be? | n/a — a default, never an authorization |

Two gates rather than one is load-bearing: a single gate with a consent parameter would let a
convenience flag switch on the admin console, seeded credentials, and the dev token endpoint. SEC-0001
§4.2 already required that decoupling; separate names mean it cannot be violated by passing the wrong argument.

## Behavior changes (both corrections)

- **Auto-DDL now honors `Koan:AllowMagicInProduction`**, as DATA-0046 always specified.
- **AI endpoint auto-discovery now runs in Staging/Test/CI** with a warning, per MESS-0026. Production unchanged.

## Enforcement

The rule was already documented the last time it drifted, because a direct `IsDevelopment()` read
compiles and looks like correct code. `EnvironmentGateConformanceSpec` scans `src/` and enumerates every
direct read with its reason; a new one fails the build with a message naming the three gates. It is a
two-way ratchet keyed by file **and count**, so a gate added inside an allowed file is caught too.
Mutation-verified in both directions.

Three sites keep direct reads and say why in place: `DataAxisPreflight` (nothing may unlock a
cross-tenant leak), `IssuerKeyGuard` (spans Staging, own acknowledgement), `IssuerKeyRotationService`
(gates no surface). Diagnostics reads are untouched.

## Evidence

- Solution builds **0 warnings, 0 errors**
- Core 350 · Data Core 474 · Identity 90 · MCP Conformance 84 · Auth Server 50 · Classification 60 ·
  Sqlite 48 · Relational 18 · Admin 13 · OpenAPI 12 · Tenancy Web 13 · MCP Explorer 16 — green
- `docs-lint` 0 errors · `skills-verify` passed
- ADR: `docs/decisions/ARCH-0128-environment-posture-is-a-named-decision.md`

## Release

21 packages, including `Sylin.Koan.Core 1.0.5`. Plan verified locally against nuget.org before push.

## Known, pre-existing

`Koan.Tenancy.Tests` has 5 failing cache-evict convergence specs. Verified by stash to fail identically
on clean `dev` — unrelated to this change, and the currently published package carries the same defect.